### PR TITLE
Add HealthCheckResultAssertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <!-- Versions for provided dependencies -->
         <assertj.version>3.16.1</assertj.version>
         <dropwizard.version>2.0.10</dropwizard.version>
-        <dropwizard.metrics.version>4.1.19</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.1.9</dropwizard.metrics.version>
         <jackson.version>2.10.4</jackson.version>
         <jsonassert.version>1.5.0</jsonassert.version>
         <lombok.version>1.18.12</lombok.version>
@@ -166,6 +166,20 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${dropwizard.metrics.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-healthchecks</artifactId>
+            <version>${dropwizard.metrics.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertions.java
+++ b/src/main/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertions.java
@@ -1,0 +1,351 @@
+package org.kiwiproject.test.assertj.dropwizard.metrics;
+
+import com.codahale.metrics.health.HealthCheck;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.kiwiproject.base.KiwiStrings;
+
+/**
+ * Provides for fluent {@link HealthCheck} tests using AssertJ assertions.
+ * <p>
+ * All methods return 'this' to facilitate a fluent API via method chaining.
+ * <p>
+ * Note that both io.dropwizard.metrics:metrics-healthchecks and io.dropwizard.metrics:metrics-core must
+ * be available at runtime.
+ */
+@SuppressWarnings("UnusedReturnValue")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class HealthCheckResultAssertions {
+
+    private final HealthCheck.Result result;
+
+    /**
+     * Starting point for health check fluent assertions on a {@link HealthCheck}.
+     * <p>
+     * Executes the health check, returning this instance for fluent assertion chaining.
+     *
+     * @param healthCheck the health check to execute
+     * @return this instance
+     */
+    public static HealthCheckResultAssertions assertThat(HealthCheck healthCheck) {
+        return assertThatHealthCheck(healthCheck);
+    }
+
+    /**
+     * Starting point for health check fluent assertions on a {@link HealthCheck}.
+     * <p>
+     * Executes the health check, returning this instance for fluent assertion chaining.
+     * <p>
+     * This method is provided as an alias of {@link #assertThat(HealthCheck)} to avoid conflicts
+     * when statically importing AssertJ's {@code Assertions#assertThat}, and therefore allow both
+     * to be statically imported.
+     *
+     * @param healthCheck the health check to execute
+     * @return this instance
+     */
+    public static HealthCheckResultAssertions assertThatHealthCheck(HealthCheck healthCheck) {
+        var result = healthCheck.execute();
+        return assertThat(result);
+    }
+
+    /**
+     * Starting point for health check fluent assertions on a {@link HealthCheck.Result}.
+     *
+     * @param result the health check result to assert upon
+     * @return this instance
+     */
+    public static HealthCheckResultAssertions assertThat(HealthCheck.Result result) {
+        return assertThatResult(result);
+    }
+
+    /**
+     * Starting point for health check fluent assertions on a {@link HealthCheck.Result}.
+     * <p>
+     * This method is provided as an alias of {@link #assertThat(HealthCheck.Result)} to avoid conflicts
+     * when statically importing AssertJ's {@code Assertions#assertThat}, and therefore allow both
+     * to be statically imported.
+     *
+     * @param result the health check result to assert upon
+     * @return this instance
+     */
+    public static HealthCheckResultAssertions assertThatResult(HealthCheck.Result result) {
+        return new HealthCheckResultAssertions(result);
+    }
+
+    /**
+     * Asserts the health check result is healthy.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions isHealthy() {
+        Assertions.assertThat(result.isHealthy())
+                .describedAs("Expected result to be healthy")
+                .isTrue();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result is not healthy.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions isUnhealthy() {
+        Assertions.assertThat(result.isHealthy())
+                .describedAs("Expected result to be unhealthy")
+                .isFalse();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has the given message.
+     *
+     * @param message the expected message
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasMessage(String message) {
+        Assertions.assertThat(result.getMessage())
+                .describedAs("Wrong message")
+                .isEqualTo(message);
+
+        return this;
+    }
+
+    /**
+     * Asserts the heath check result contains the given message fragment.
+     *
+     * @param messageFragment the expected message fragment
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasMessageContaining(String messageFragment) {
+        Assertions.assertThat(result.getMessage())
+                .describedAs("Wrong message fragment")
+                .contains(messageFragment);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result starts with the given message prefix.
+     *
+     * @param messagePrefix the expected message prefix
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasMessageStartingWith(String messagePrefix) {
+        Assertions.assertThat(result.getMessage())
+                .describedAs("Wrong message prefix")
+                .startsWith(messagePrefix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result ends with the given message suffix.
+     *
+     * @param messageSuffix the expected message suffix
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasMessageEndingWith(String messageSuffix) {
+        Assertions.assertThat(result.getMessage())
+                .describedAs("Wrong message suffix")
+                .endsWith(messageSuffix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has a message interpolated using the given message template and arguments.
+     *
+     * @param messageTemplate the message template to use
+     * @param args            the arguments for the template
+     * @return this instance
+     * @implNote This uses {@link KiwiStrings#format(String, Object...)} to format {@code messageTemplate} using the
+     * given {@code args}. THIS MEANS IT WILL NOT WORK if you assume it uses {@link String#format(String, Object...)}
+     * formatting specifiers.
+     * @see KiwiStrings#format(String, Object...)
+     */
+    public HealthCheckResultAssertions hasMessage(String messageTemplate, Object... args) {
+        Assertions.assertThat(result.getMessage())
+                .describedAs("Wrong formatted message")
+                .isEqualTo(KiwiStrings.format(messageTemplate, args));
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error, i.e. {@link HealthCheck.Result#getError()} returns a non-null
+     * result.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasError() {
+        assertResultHasError();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has a null error.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasNoError() {
+        Assertions.assertThat(result.getError())
+                .describedAs("Expected not to have an error")
+                .isNull();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error whose type is an instance of the given type.
+     *
+     * @param type the expected type
+     * @return this instance
+     * @implNote Uses {@link org.assertj.core.api.AbstractAssert#isInstanceOf(Class)}
+     */
+    public HealthCheckResultAssertions hasErrorInstanceOf(Class<?> type) {
+        Assertions.assertThat(result.getError())
+                .describedAs("Wrong error type")
+                .isInstanceOf(type);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error whose type is EXACTLY the given type.
+     *
+     * @param type the expected exact type
+     * @return this instance
+     * @implNote Uses {@link org.assertj.core.api.AbstractAssert#isExactlyInstanceOf(Class)}
+     */
+    public HealthCheckResultAssertions hasErrorExactlyInstanceOf(Class<?> type) {
+        Assertions.assertThat(result.getError())
+                .describedAs("Wrong exact error type")
+                .isExactlyInstanceOf(type);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error with the given message.
+     *
+     * @param message the expected message
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasErrorWithMessage(String message) {
+        assertResultHasError();
+
+        Assertions.assertThat(result.getError().getMessage())
+                .describedAs("Wrong error message")
+                .isEqualTo(message);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error that contains the given message fragment.
+     *
+     * @param messageFragment the expected message fragment
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasErrorWithMessageContaining(String messageFragment) {
+        assertResultHasError();
+
+        Assertions.assertThat(result.getError().getMessage())
+                .describedAs("Wrong error message fragment")
+                .contains(messageFragment);
+
+        return this;
+    }
+
+    private void assertResultHasError() {
+        Assertions.assertThat(result.getError())
+                .describedAs("Expected to have an error")
+                .isNotNull();
+    }
+
+    /**
+     * Asserts the health check result has an empty map of details.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasEmptyDetails() {
+        Assertions.assertThat(result.getDetails())
+                .describedAs("Expected empty (non-null) details")
+                .isEmpty();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has a null map of details.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasNullDetails() {
+        Assertions.assertThat(result.getDetails())
+                .describedAs("Expected null details")
+                .isNull();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an empty or null map of details.
+     *
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasNullOrEmptyDetails() {
+        Assertions.assertThat(result.getDetails())
+                .describedAs("Expected null or empty details")
+                .isNullOrEmpty();
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has a detail with the given key.
+     *
+     * @param key the expected key
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasDetailsContainingKey(String key) {
+        Assertions.assertThat(result.getDetails())
+                .describedAs("Expected key not found in details")
+                .containsKey(key);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has details containing all the given keys.
+     *
+     * @param keys the expected keys
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasDetailsContainingKeys(String... keys) {
+        Assertions.assertThat(result.getDetails())
+                .describedAs("Expected keys not found in details")
+                .containsKeys(keys);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has a detail with the given key and value.
+     *
+     * @param key   the expected key
+     * @param value the expected value
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasDetail(String key, Object value) {
+        Assertions.assertThat(result.getDetails())
+                .describedAs("Expected detail not found")
+                .containsEntry(key, value);
+
+        return this;
+    }
+}

--- a/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
@@ -1,0 +1,612 @@
+package org.kiwiproject.test.assertj.dropwizard.metrics;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThat;
+
+import com.codahale.metrics.health.HealthCheck;
+import lombok.Builder;
+import lombok.Singular;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.util.Map;
+
+@DisplayName("HealthCheckResultAssertions")
+class HealthCheckResultAssertionsTest {
+
+    /**
+     * A simple "real mock" health check used in this test.
+     */
+    @Builder
+    static class MockHealthCheck extends HealthCheck {
+
+        @Builder.Default
+        private final boolean healthy = true;
+
+        private final String message;
+
+        private final Exception error;
+
+        @Builder.Default
+        private final boolean throwExceptionOnCheck = false;
+
+        // NOTE: @Singular always creates a non-null collection
+        @Singular
+        private final Map<String, Object> details;
+
+        @Override
+        protected Result check() throws Exception {
+            if (throwExceptionOnCheck) {
+                throw error;
+            }
+
+            var resultBuilder = Result.builder().withMessage(message);
+
+            if (healthy) {
+                resultBuilder.healthy();
+            } else if (nonNull(error)) {
+                resultBuilder.unhealthy(error);
+            } else {
+                resultBuilder.unhealthy();
+            }
+
+            details.forEach(resultBuilder::withDetail);
+
+            return resultBuilder.build();
+        }
+    }
+
+    @Nested
+    class IsHealthy {
+
+        @Test
+        void shouldPass_WhenHealthy() {
+            var healthCheck = MockHealthCheck.builder().healthy(true).build();
+
+            assertThatCode(() -> assertThat(healthCheck).isHealthy())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenNotHealthy() {
+            var healthCheck = MockHealthCheck.builder().healthy(false).build();
+
+            assertThatThrownBy(() -> assertThat(healthCheck).isHealthy())
+                    .isNotNull()
+                    .hasMessageContaining("Expected result to be healthy");
+        }
+    }
+
+    @Nested
+    class IsUnhealthy {
+
+        @Test
+        void shouldPass_WhenNotHealthy() {
+            var healthCheck = MockHealthCheck.builder().healthy(false).build();
+
+            assertThatCode(() -> assertThat(healthCheck).isUnhealthy())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFail_WhenHealthy() {
+            var healthCheck = MockHealthCheck.builder().healthy(true).build();
+
+            assertThatThrownBy(() -> assertThat(healthCheck).isUnhealthy())
+                    .isNotNull()
+                    .hasMessageContaining("Expected result to be unhealthy");
+        }
+    }
+
+    @Nested
+    class HasMessageMethods {
+
+        private HealthCheck healthCheck;
+
+        @BeforeEach
+        void setUp() {
+            healthCheck = MockHealthCheck.builder().message("The answer is 42").build();
+        }
+
+        @Nested
+        class HasMessage {
+
+            @Test
+            void shouldPass_WhenMethodEquals() {
+                assertThatCode(() -> assertThat(healthCheck)
+                        .isHealthy()
+                        .hasMessage("The answer is 42")
+                ).doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenMessageDoesNotEqual() {
+                assertThatThrownBy(() -> assertThat(healthCheck)
+                        .isHealthy()
+                        .hasMessage("The answer to the ultimate question is most definitely 42")
+                ).hasMessageContaining("Wrong message");
+            }
+        }
+
+        @Nested
+        class HasMessageWithVarargs {
+
+            @Test
+            void shouldPass_WhenMessageEquals() {
+                assertThatCode(() -> assertThat(healthCheck)
+                        .isHealthy()
+                        .hasMessage("The {} is {}", "answer", 42)
+                ).doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenMessageDoesNotEqual() {
+                assertThatThrownBy(() -> assertThat(healthCheck)
+                        .isHealthy()
+                        .hasMessage("The {} to the {} question is most definitely {}", "answer", "ultimate", 42)
+                ).hasMessageContaining("Wrong formatted message");
+            }
+        }
+
+        @Nested
+        class HasMessageContaining {
+
+            @Test
+            void shouldPass_WhenErrorMessageContains() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasMessageContaining("answer is")
+                ).doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotContain() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasMessageContaining("ultimate question")
+                ).hasMessageContaining("Wrong message fragment");
+            }
+        }
+
+        @Nested
+        class HasMessageStartingWith {
+
+            @Test
+            void shouldPass_WhenErrorMessageStartsWith() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasMessageStartingWith("The answer"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotStartWith() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasMessageStartingWith("answer is"))
+                        .hasMessageContaining("Wrong message prefix");
+            }
+        }
+
+        @Nested
+        class HasMessageEndingWith {
+
+            @Test
+            void shouldPass_WhenErrorMessageEndsWith() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasMessageEndingWith("is 42"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotStartWith() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasMessageEndingWith("something else"))
+                        .hasMessageContaining("Wrong message suffix");
+            }
+        }
+    }
+
+    @Nested
+    class ErrorMethods {
+
+        private HealthCheck healthCheck;
+
+        @BeforeEach
+        void setUp() {
+            var error = new CertificateExpiredException("it's way out of date");
+            healthCheck = MockHealthCheck.builder().healthy(false).error(error).build();
+        }
+
+        @Nested
+        class HasError {
+
+            @Test
+            void shouldPass_WhenHasError() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasError())
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenHasNoError() {
+                var noErrorHealthCheck = MockHealthCheck.builder().healthy(false).build();
+
+                assertThatThrownBy(() ->
+                        assertThat(noErrorHealthCheck)
+                                .isUnhealthy()
+                                .hasError())
+                        .hasMessageContaining("Expected to have an error");
+            }
+        }
+
+        @Nested
+        class HasNoError {
+
+            @Test
+            void shouldPass_WhenHasNoError() {
+                var noErrorHealthCheck = MockHealthCheck.builder().build();
+
+                assertThatCode(() ->
+                        assertThat(noErrorHealthCheck)
+                                .isHealthy()
+                                .hasNoError())
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenHasError() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasNoError())
+                        .hasMessageContaining("Expected not to have an error");
+            }
+        }
+
+        @Nested
+        class HasErrorInstanceOf {
+
+            @Test
+            void shouldPass_WhenErrorIsInstanceOfType() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorInstanceOf(CertificateException.class))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorHasIncorrectType() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorInstanceOf(IllegalStateException.class))
+                        .hasMessageContaining("Wrong error type");
+            }
+        }
+
+        @Nested
+        class HasErrorExactlyInstanceOf {
+
+            @Test
+            void shouldPass_WhenErrorIsExactType() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorExactlyInstanceOf(CertificateExpiredException.class))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorHasIncorrectType() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorExactlyInstanceOf(CertificateNotYetValidException.class))
+                        .hasMessageContaining("Wrong exact error type");
+            }
+        }
+
+        @Nested
+        class HasErrorWithMessage {
+
+            @Test
+            void shouldPass_WhenErrorMessageEquals() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .hasErrorWithMessage("it's way out of date"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotEqual() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .hasErrorWithMessage("it's only slightly out of date"))
+                        .hasMessageContaining("Wrong error message");
+            }
+        }
+
+        @Nested
+        class ErrorWithMessageContaining {
+
+            @Test
+            void shouldPass_WhenErrorMessageContains() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithMessageContaining("way out"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotContain() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .hasErrorWithMessageContaining("way beyond expiration date"))
+                        .hasMessageContaining("Wrong error message fragment");
+            }
+        }
+    }
+
+    @Nested
+    class DetailMethods {
+
+        private HealthCheck healthCheck;
+
+        @BeforeEach
+        void setUp() {
+            healthCheck = MockHealthCheck.builder()
+                    .detail("answer", 42)
+                    .detail("book", "Hitchhiker's Guide to the Galaxy")
+                    .detail("author", "Douglas Adams")
+                    .detail("pubYear", 1979)
+                    .build();
+        }
+
+        @Nested
+        class HasDetailsContainingKey {
+
+            @Test
+            void shouldPass_WhenDetailsContainExpectedKey() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetailsContainingKey("answer")
+                                .hasDetailsContainingKey("book")
+                                .hasDetailsContainingKey("author")
+                                .hasDetailsContainingKey("pubYear"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenDetailsDoesNotContainExpectedKey() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetailsContainingKey("answer")
+                                .hasDetailsContainingKey("vogon")
+                                .hasDetailsContainingKey("author"))
+                        .hasMessageContaining("Expected key not found in details");
+            }
+
+            @Test
+            void shouldFail_WhenDetailsIsNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetailsContainingKey("foo"))
+                        .hasMessageContaining("Expected key not found in details");
+            }
+        }
+
+        @Nested
+        class HasDetailsContainingKeys {
+
+            @Test
+            void shouldPass_WhenDetailsContainsExpectedKeys() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetailsContainingKeys("answer", "book", "author", "pubYear"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenDetailsDoesNotContainKey() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetailsContainingKeys("answer", "vogon", "author"))
+                        .hasMessageContaining("Expected keys not found in details");
+            }
+
+            @Test
+            void shouldFail_WhenDetailsIsNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetailsContainingKey("foo"))
+                        .hasMessageContaining("Expected key not found in details");
+            }
+        }
+
+        @Nested
+        class HasDetail {
+
+            @Test
+            void shouldPass_WhenDetailsContainExpectedKeyAndValue() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetail("answer", 42)
+                                .hasDetail("author", "Douglas Adams")
+                                .hasDetail("pubYear", 1979)
+                                .hasDetail("book", "Hitchhiker's Guide to the Galaxy"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenDetailsDoesNotContainExpectedKeyAndValue() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetail("answer", 42)
+                                .hasDetail("author", "Douglas Adams")
+                                .hasDetail("pubYear", 2005)
+                                .hasDetail("book", "The Hitchhiker's Guide to the Galaxy"))
+                        .hasMessageContaining("Expected detail not found");
+            }
+
+            @Test
+            void shouldFail_WhenDetailsIsNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasDetail("foo", "bar"))
+                        .hasMessageContaining("Expected detail not found");
+            }
+        }
+
+        @Nested
+        class HasEmptyDetails {
+
+            @Test
+            void shouldPass_WhenDetailsAreEmpty() {
+                var healthCheck = MockHealthCheck.builder().details(Map.of()).build();
+
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasEmptyDetails())
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenDetailsAreNotEmpty() {
+                var healthCheck = MockHealthCheck.builder().details(Map.of("answer", 42)).build();
+
+
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasEmptyDetails())
+                        .hasMessageContaining("Expected empty (non-null) details");
+            }
+        }
+
+        @Nested
+        class HasNullDetails {
+
+            @Test
+            void shouldPass_WhenDetailsAreNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .hasNullDetails())
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenDetailsAreNotNull() {
+                var healthCheck = MockHealthCheck.builder().detail("answer", 42).build();
+
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .hasNullDetails())
+                        .hasMessageContaining("Expected null details");
+            }
+
+        }
+
+        @Nested
+        class HasNullOrEmptyDetails {
+
+            @Test
+            void shouldPass_WhenDetailsAreNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasNullOrEmptyDetails())
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldPass_WhenDetailsAreEmpty() {
+                MockHealthCheck healthCheck = newHealthCheckWithEmptyDetails();
+
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasNullOrEmptyDetails())
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenDetailsAreNotNullOrEmpty() {
+                var healthCheck = MockHealthCheck.builder().detail("answer", 42).build();
+
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .hasNullOrEmptyDetails())
+                        .hasMessageContaining("Expected null or empty details");
+            }
+        }
+    }
+
+    private HealthCheck newHealthCheckWithNullDetails() {
+        // NOTE: Cannot use MockHealthCheck here b/c it always creates non-null details (b/c it uses @Singular)
+        return new HealthCheck() {
+
+            @Override
+            protected Result check() {
+                var result = Result.healthy("Healthy, but null details");
+                var details = result.getDetails();
+                verify(isNull(details),
+                        "Incorrect state: assuming null details but details are: %s", details);
+
+                return result;
+            }
+        };
+    }
+
+    private MockHealthCheck newHealthCheckWithEmptyDetails() {
+        var healthCheck = MockHealthCheck.builder().build();
+        var result = healthCheck.execute();
+        var details = result.getDetails();
+        verify(nonNull(details) && details.isEmpty(),
+                "Incorrect state: assuming empty details but details are: %s", details);
+        return healthCheck;
+    }
+
+}


### PR DESCRIPTION
* Fix incorrect Metrics version in pom. Set to 4.1.9
* Add metrics-core and metrics-healthchecks dependencies
  as provided scope. Both are needed in order to use
  HealthCheckResultAssertions at runtime
* Add HealthCheckResultAssertions test utility

Fixes #23