### PR TITLE
Update to Dropwizard 2.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,18 +74,20 @@
         <byte.buddy.version>1.10.10</byte.buddy.version>
         <commons-text.version>1.8</commons-text.version>
         <curator.version>2.13.0</curator.version>
-        <dropwizard.version>2.0.10</dropwizard.version>
-        <dropwizard.metrics.version>4.1.9</dropwizard.metrics.version>
+        <dropwizard.version>2.0.12</dropwizard.version>
+        <dropwizard.metrics.version>4.1.11</dropwizard.metrics.version>
         <hibernate.version>5.4.16.Final</hibernate.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <javassist.version>3.27.0-GA</javassist.version>
-        <jackson.version>2.10.4</jackson.version>
+        <jackson.version>2.10.5</jackson.version>
+        <jersey-test-framework-core.version>2.31</jersey-test-framework-core.version>
         <jsonassert.version>1.5.0</jsonassert.version>
         <lombok.version>1.18.12</lombok.version>
         <zookeeper.version>3.4.14</zookeeper.version>
 
         <!-- Versions for optional dependencies -->
+        <error_prone_annotations.version>2.4.0</error_prone_annotations.version>
 
         <!-- Versions for test dependencies -->
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
@@ -140,6 +142,10 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -147,6 +153,13 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
             <version>${kiwi.version}</version>
+            <exclusions>
+                <!-- TODO: Revisit this exclusion when kiwi 0.8.0 is released -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -335,6 +348,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+            <version>${jersey-test-framework-core.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${dropwizard.metrics.version}</version>
@@ -407,6 +433,13 @@
         </dependency>
 
         <!-- optional dependencies -->
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>${error_prone_annotations.version}</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- nothing here yet...move along... -->
 


### PR DESCRIPTION
* dropwizard 2.0.12
* metrics 4.1.11
* jackson 2.10.5
* added explicit error_prone_annotations and jersey-test-framework-core
  dependencies, as well as excluding error_prone_annotations from guava,
  in order to resolve maven dependency convergence issues
* exclude (temporary) commons-lang3 form kiwi due to convergence error

Fixes #43