### PR TITLE
Add DropwizardMockitoMocks

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoContext.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoContext.java
@@ -1,0 +1,32 @@
+package org.kiwiproject.test.dropwizard.mockito;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import javax.validation.Validator;
+
+/**
+ * Contains all the various top-level objects in a Dropwizard application.
+ * <p>
+ * The contained objects are specifically intended to be Mockito mocks, but this is not checked in any way.
+ */
+@Getter
+@Accessors(fluent = true)
+@Builder(access = AccessLevel.PACKAGE)
+public class DropwizardMockitoContext {
+    private final Environment environment;
+    private final JerseyEnvironment jersey;
+    private final HealthCheckRegistry healthChecks;
+    private final MetricRegistry metrics;
+    private final LifecycleEnvironment lifecycle;
+    private final ObjectMapper objectMapper;
+    private final Validator validator;
+}

--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
@@ -65,8 +65,8 @@ public class DropwizardMockitoMocks {
      *
      * @return a context object providing easy access to the mocked Dropwizard application objects
      */
-    public static DropwizardMockitoContext mockDropwizardEnvironment() {
-        return mockDropwizardEnvironment(OBJECT_MAPPER, ValidationTestHelper.getValidator());
+    public static DropwizardMockitoContext mockDropwizard() {
+        return mockDropwizard(OBJECT_MAPPER, ValidationTestHelper.getValidator());
     }
 
     /**
@@ -78,7 +78,7 @@ public class DropwizardMockitoMocks {
      * @param validator the {@link Validator} that the mocked environment should return
      * @return a context object providing easy access to the mocked Dropwizard application objects
      */
-    public static DropwizardMockitoContext mockDropwizardEnvironment(ObjectMapper mapper, Validator validator) {
+    public static DropwizardMockitoContext mockDropwizard(ObjectMapper mapper, Validator validator) {
         var env = mock(Environment.class);
         useObjectMapper(env, mapper);
         useValidator(env, validator);

--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
@@ -1,0 +1,177 @@
+package org.kiwiproject.test.dropwizard.mockito;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.test.constants.KiwiTestConstants.OBJECT_MAPPER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Verify;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.test.validation.ValidationTestHelper;
+import org.mockito.Mockito;
+
+import javax.validation.Validator;
+
+/**
+ * Creates Mockito mocks of Dropwizard application level objects.
+ * <p>
+ * This should be used rarely and only in specific situations where you might not want to use the
+ * {@link io.dropwizard.testing.junit5.DropwizardAppExtension} to test a Dropwizard application.
+ */
+@UtilityClass
+public class DropwizardMockitoMocks {
+
+    /**
+     * Mock the Dropwizard application environment.
+     * <p>
+     * All objects returned by the mock {@link Environment} are themselves mock objects.
+     *
+     * @return a mock {@link Environment} that returns mock Dropwizard application objects
+     */
+    public static Environment mockEnvironment() {
+        return mockEnvironment(OBJECT_MAPPER, ValidationTestHelper.getValidator());
+    }
+
+    /**
+     * Mock the Dropwizard application environment.
+     * <p>
+     * All objects returned by the mock {@link Environment} are themselves mock objects.
+     *
+     * @param mapper    the {@link ObjectMapper} that the mocked environment should return
+     * @param validator the {@link Validator} that the mocked environment should return
+     * @return a mock {@link Environment} that returns mock Dropwizard application objects
+     */
+    public static Environment mockEnvironment(ObjectMapper mapper, Validator validator) {
+        var env = mock(Environment.class);
+        mockJerseyEnvironment(env);
+        mockHealthCheckRegistry(env);
+        mockMetricRegistry(env);
+        mockLifecycleEnvironment(env);
+        useObjectMapper(env, mapper);
+        useValidator(env, validator);
+        return env;
+    }
+
+    /**
+     * Mock the Dropwizard application environment.
+     * <p>
+     * All objects contained in the {@link DropwizardMockitoContext} are mocks.
+     *
+     * @return a context object providing easy access to the mocked Dropwizard application objects
+     */
+    public static DropwizardMockitoContext mockDropwizardEnvironment() {
+        return mockDropwizardEnvironment(OBJECT_MAPPER, ValidationTestHelper.getValidator());
+    }
+
+    /**
+     * Mock the Dropwizard application environment.
+     * <p>
+     * All objects contained in the {@link DropwizardMockitoContext} are mocks.
+     *
+     * @param mapper    the {@link ObjectMapper} that the mocked environment should return
+     * @param validator the {@link Validator} that the mocked environment should return
+     * @return a context object providing easy access to the mocked Dropwizard application objects
+     */
+    public static DropwizardMockitoContext mockDropwizardEnvironment(ObjectMapper mapper, Validator validator) {
+        var env = mock(Environment.class);
+        useObjectMapper(env, mapper);
+        useValidator(env, validator);
+
+        return DropwizardMockitoContext.builder()
+                .environment(env)
+                .jersey(mockJerseyEnvironment(env))
+                .healthChecks(mockHealthCheckRegistry(env))
+                .metrics(mockMetricRegistry(env))
+                .lifecycle(mockLifecycleEnvironment(env))
+                .objectMapper(mapper)
+                .validator(validator)
+                .build();
+    }
+
+    /**
+     * Mock the {@link JerseyEnvironment} in the given Dropwizard environment.
+     *
+     * @param mockEnv a mock {@link Environment}
+     * @return a mock {@link JerseyEnvironment}
+     */
+    public static JerseyEnvironment mockJerseyEnvironment(Environment mockEnv) {
+        verifyIsMockitoMock(mockEnv);
+        var jersey = mock(JerseyEnvironment.class);
+        when(mockEnv.jersey()).thenReturn(jersey);
+        return jersey;
+    }
+
+    /**
+     * Mock the {@link HealthCheckRegistry} in the given Dropwizard environment.
+     *
+     * @param mockEnv a mock {@link Environment}
+     * @return a mock {@link HealthCheckRegistry}
+     */
+    public static HealthCheckRegistry mockHealthCheckRegistry(Environment mockEnv) {
+        verifyIsMockitoMock(mockEnv);
+        var healthCheckRegistry = mock(HealthCheckRegistry.class);
+        when(mockEnv.healthChecks()).thenReturn(healthCheckRegistry);
+        return healthCheckRegistry;
+    }
+
+    /**
+     * Mock the {@link MetricRegistry} in the given Dropwizard environment.
+     *
+     * @param mockEnv a mock {@link Environment}
+     * @return a mock {@link MetricRegistry}
+     */
+    public static MetricRegistry mockMetricRegistry(Environment mockEnv) {
+        verifyIsMockitoMock(mockEnv);
+        var metricRegistry = mock(MetricRegistry.class);
+        when(mockEnv.metrics()).thenReturn(metricRegistry);
+        return metricRegistry;
+    }
+
+    /**
+     * Mock the {@link LifecycleEnvironment} in the given Dropwizard environment.
+     *
+     * @param mockEnv a mock {@link Environment}
+     * @return a mock {@link LifecycleEnvironment}
+     */
+    public static LifecycleEnvironment mockLifecycleEnvironment(Environment mockEnv) {
+        verifyIsMockitoMock(mockEnv);
+        var lifecycleEnvironment = mock(LifecycleEnvironment.class);
+        when(mockEnv.lifecycle()).thenReturn(lifecycleEnvironment);
+        return lifecycleEnvironment;
+    }
+
+    /**
+     * Mock the given Dropwizard environment to return the given {@link ObjectMapper}.
+     *
+     * @param mockEnv a mock {@link Environment}
+     * @param mapper  the mapper that the mocked environment should return
+     */
+    public static void useObjectMapper(Environment mockEnv, ObjectMapper mapper) {
+        verifyIsMockitoMock(mockEnv);
+        checkArgumentNotNull(mapper);
+        when(mockEnv.getObjectMapper()).thenReturn(mapper);
+    }
+
+    /**
+     * Mock the given Dropwizard environment to return the given {@link Validator}.
+     *
+     * @param mockEnv   a mock {@link Environment}
+     * @param validator the validator that the mocked environment should return
+     */
+    public static void useValidator(Environment mockEnv, Validator validator) {
+        verifyIsMockitoMock(mockEnv);
+        checkArgumentNotNull(validator);
+        when(mockEnv.getValidator()).thenReturn(validator);
+    }
+
+    private static void verifyIsMockitoMock(Environment environment) {
+        checkArgumentNotNull(environment);
+        Verify.verify(Mockito.mockingDetails(environment).isMock(), "environment must be a Mockito mock");
+    }
+}

--- a/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
@@ -1,0 +1,223 @@
+package org.kiwiproject.test.dropwizard.mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.test.constants.KiwiTestConstants.OBJECT_MAPPER;
+import static org.mockito.Mockito.mock;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.common.base.VerifyException;
+import io.dropwizard.Configuration;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.setup.Environment;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.test.validation.ValidationTestHelper;
+import org.mockito.Mockito;
+
+import javax.validation.Validation;
+
+@DisplayName("DropwizardMockitoMocks")
+class DropwizardMockitoMocksTest {
+
+    @Nested
+    class MockEnvironment {
+
+        private Environment env;
+
+        @BeforeEach
+        void setUp() {
+            env = DropwizardMockitoMocks.mockEnvironment();
+        }
+
+        @Test
+        void shouldReturnEnvironment() {
+            assertIsMockitoMock(env);
+        }
+
+        @Test
+        void shouldSetJerseyEnvironment() {
+            assertIsMockitoMock(env.jersey());
+        }
+
+        @Test
+        void shouldSetHealthCheckRegistry() {
+            assertIsMockitoMock(env.healthChecks());
+        }
+
+        @Test
+        void shouldSetMetricRegistry() {
+            assertIsMockitoMock(env.metrics());
+        }
+
+        @Test
+        void shouldSetLifecycleEnvironment() {
+            assertIsMockitoMock(env.lifecycle());
+        }
+
+        @Test
+        void shouldSetObjectMapper() {
+            assertThat(env.getObjectMapper()).isSameAs(OBJECT_MAPPER);
+        }
+
+        @Test
+        void shouldSetValidator() {
+            assertThat(env.getValidator()).isSameAs(ValidationTestHelper.getValidator());
+        }
+    }
+
+    @Nested
+    class MockDropwizardEnvironment {
+
+        private DropwizardMockitoContext context;
+
+        @BeforeEach
+        void setUp() {
+            context = DropwizardMockitoMocks.mockDropwizardEnvironment();
+        }
+
+        @Test
+        void shouldSetEnvironment() {
+            assertIsMockitoMock(context.environment());
+        }
+
+        @Test
+        void shouldSetJerseyEnvironment() {
+            var jersey = context.jersey();
+            assertIsMockitoMock(jersey);
+            assertThat(context.environment().jersey()).isSameAs(jersey);
+        }
+
+        @Test
+        void shouldSetHealthCheckRegistry() {
+            var healthChecks = context.healthChecks();
+            assertIsMockitoMock(healthChecks);
+            assertThat(context.environment().healthChecks()).isSameAs(healthChecks);
+        }
+
+        @Test
+        void shouldSetMetricRegistry() {
+            var metrics = context.metrics();
+            assertIsMockitoMock(metrics);
+            assertThat(context.environment().metrics()).isSameAs(metrics);
+        }
+
+        @Test
+        void shouldSetLifecycleEnvironment() {
+            var lifecycle = context.lifecycle();
+            assertIsMockitoMock(lifecycle);
+            assertThat(context.environment().lifecycle()).isSameAs(lifecycle);
+        }
+
+        @Test
+        void shouldSetObjectMapper() {
+            var mapper = context.objectMapper();
+            assertThat(mapper).isSameAs(OBJECT_MAPPER);
+            assertThat(context.environment().getObjectMapper()).isSameAs(mapper);
+        }
+
+        @Test
+        void shouldSetValidator() {
+            var validator = context.validator();
+            assertThat(validator).isSameAs(ValidationTestHelper.getValidator());
+            assertThat(context.environment().getValidator()).isSameAs(validator);
+        }
+    }
+
+    @Nested
+    class MethodsRequiringMockEnvironment {
+
+        private Environment env;
+
+        @BeforeEach
+        void setUp() {
+            env = mock(Environment.class);
+        }
+
+        @Test
+        void shouldRequireMockitoMocks() {
+            var realEnv = new Environment(
+                    "test",
+                    OBJECT_MAPPER,
+                    Validation.buildDefaultValidatorFactory(),
+                    new MetricRegistry(),
+                    Thread.currentThread().getContextClassLoader(),
+                    new HealthCheckRegistry(),
+                    new TestConfig()
+            );
+
+            SoftAssertions.assertSoftly(softly -> {
+                assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockJerseyEnvironment(realEnv));
+                assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockHealthCheckRegistry(realEnv));
+                assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockMetricRegistry(realEnv));
+                assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockLifecycleEnvironment(realEnv));
+                assertVerifyExceptionThrownBy(softly,
+                        () -> DropwizardMockitoMocks.useObjectMapper(realEnv, OBJECT_MAPPER));
+                assertVerifyExceptionThrownBy(softly,
+                        () -> DropwizardMockitoMocks.useValidator(realEnv, ValidationTestHelper.getValidator()));
+            });
+        }
+
+        private void assertVerifyExceptionThrownBy(SoftAssertions softly,
+                                                   ThrowableAssert.ThrowingCallable callable) {
+            softly.assertThatThrownBy(callable)
+                    .isExactlyInstanceOf(VerifyException.class)
+                    .hasMessage("environment must be a Mockito mock");
+        }
+
+        @Test
+        void shouldMockJerseyEnvironment() {
+            var jersey = DropwizardMockitoMocks.mockJerseyEnvironment(env);
+            assertIsMockitoMock(jersey);
+            assertThat(env.jersey()).isSameAs(jersey);
+        }
+
+        @Test
+        void shouldMockHealthCheckRegistry() {
+            var healthChecks = DropwizardMockitoMocks.mockHealthCheckRegistry(env);
+            assertIsMockitoMock(healthChecks);
+            assertThat(env.healthChecks()).isSameAs(healthChecks);
+        }
+
+        @Test
+        void shouldMockMetricRegistry() {
+            var metrics = DropwizardMockitoMocks.mockMetricRegistry(env);
+            assertIsMockitoMock(metrics);
+            assertThat(env.metrics()).isSameAs(metrics);
+        }
+
+        @Test
+        void shouldMockLifecycleEnvironment() {
+            var lifecycle = DropwizardMockitoMocks.mockLifecycleEnvironment(env);
+            assertIsMockitoMock(lifecycle);
+            assertThat(env.lifecycle()).isSameAs(lifecycle);
+        }
+
+        @Test
+        void shouldUseObjectMapper() {
+            var mapper = Jackson.newMinimalObjectMapper();
+            DropwizardMockitoMocks.useObjectMapper(env, mapper);
+            assertThat(env.getObjectMapper()).isSameAs(mapper);
+        }
+
+        @Test
+        void shouldUseValidator() {
+            var validator = ValidationTestHelper.newValidator();
+            DropwizardMockitoMocks.useValidator(env, validator);
+            assertThat(env.getValidator()).isSameAs(validator);
+        }
+    }
+
+    private static void assertIsMockitoMock(Object object) {
+        assertThat(object).isNotNull();
+        assertThat(Mockito.mockingDetails(object).isMock()).isTrue();
+    }
+
+    static class TestConfig extends Configuration {
+    }
+
+}

--- a/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
@@ -71,13 +71,13 @@ class DropwizardMockitoMocksTest {
     }
 
     @Nested
-    class MockDropwizardEnvironment {
+    class MockDropwizard {
 
         private DropwizardMockitoContext context;
 
         @BeforeEach
         void setUp() {
-            context = DropwizardMockitoMocks.mockDropwizardEnvironment();
+            context = DropwizardMockitoMocks.mockDropwizard();
         }
 
         @Test


### PR DESCRIPTION
* Add DropwizardMockitoMocks and test
* Add DropwizardMockitoContext, used as a return value in
  DropwizardMockitoMocks#mockDropwizardEnvironment

**Question:** I could not think of a decent name for the method that returns a `DropwizardMockitoContext` so it is just named `mockDropwizardEnvironment` as opposed to just `mockEnvironment` for the one that returns the `Environment`. Can you think of a better name? 

Fixes #31