### PR TITLE
Add call to `afterAll` on `PostgresTestAppExtension` to cleanup after…

### DIFF
--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import javax.validation.Valid;
@@ -21,10 +23,16 @@ import javax.validation.constraints.NotNull;
 
 /**
  * @implNote Due to several known issues in the zonkyio / embedded-postgres library on macOS Catalina,
- * we are enabling this only on Linux. See https://github.com/zonkyio/embedded-postgres/issues/32
- * and https://github.com/zonkyio/embedded-postgres/issues/40 for more details.
+ * we are enabling this only on Linux at present. See issues
+ * <a href="https://github.com/zonkyio/embedded-postgres/issues/32">32</a>,
+ * <a href="https://github.com/zonkyio/embedded-postgres/issues/40">40</a> for more details.
+ * Also, issue <a href="https://github.com/zonkyio/embedded-postgres/issues/11">11</a> is related and
+ * <a href="https://github.com/zonkyio/embedded-postgres/issues/11#issuecomment-533468269">this comment</a>
+ * explains how to "fix" by exporting {@code LC_CTYPE} and {@code LC_ALL} environment variables if you want
+ * to run this test on macOS.
  */
 @DisplayName("PostgresAppTestExtension")
+@EnabledOnOs(OS.LINUX)
 class PostgresAppTestExtensionTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -10,10 +10,10 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import lombok.Getter;
 import lombok.Setter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import javax.validation.Valid;
@@ -25,7 +25,6 @@ import javax.validation.constraints.NotNull;
  * and https://github.com/zonkyio/embedded-postgres/issues/40 for more details.
  */
 @DisplayName("PostgresAppTestExtension")
-@EnabledOnOs(OS.LINUX)
 class PostgresAppTestExtensionTest {
 
     @Getter
@@ -44,17 +43,28 @@ class PostgresAppTestExtensionTest {
         }
     }
 
+    private final static PostgresAppTestExtension<Config> EXTENSION = new PostgresAppTestExtension<>("PostgresAppTestExtensionTest/test-migrations.xml",
+            "PostgresAppTestExtensionTest/test-config.yml",
+            App.class);
+
+    private static ExtensionContext mockContext;
+
+    @BeforeAll
+    static void setupAndStartExtension() throws Exception {
+        mockContext = mock(ExtensionContext.class);
+        EXTENSION.beforeAll(mockContext);
+    }
+
+    @AfterAll
+    static void stopExtension() {
+        EXTENSION.afterAll(mockContext);
+    }
+
     @Test
-    void shouldStartPostgresAndApp() throws Exception {
-        var extension = new PostgresAppTestExtension<>("PostgresAppTestExtensionTest/test-migrations.xml",
-                "PostgresAppTestExtensionTest/test-config.yml",
-                App.class);
-
-        extension.beforeAll(mock(ExtensionContext.class));
-
-        assertThat(extension.getApp()).isNotNull();
-        assertThat(extension.getApp().getTestSupport().getEnvironment()).isNotNull();
-        assertThat(extension.getPostgres()).isNotNull();
-        assertThat(extension.getPostgres().getTestDatabase()).isNotNull();
+    void shouldStartPostgresAndApp() {
+        assertThat(EXTENSION.getApp()).isNotNull();
+        assertThat(EXTENSION.getApp().getTestSupport().getEnvironment()).isNotNull();
+        assertThat(EXTENSION.getPostgres()).isNotNull();
+        assertThat(EXTENSION.getPostgres().getTestDatabase()).isNotNull();
     }
 }


### PR DESCRIPTION
… test

Fixes #78