### PR TITLE
Add StandardExceptionTests (migrated from dropwizard-curator)

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/StandardExceptionTests.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/StandardExceptionTests.java
@@ -1,0 +1,185 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import lombok.experimental.UtilityClass;
+import org.junit.jupiter.api.DynamicTest;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Utilities to generate {@link DynamicTest}s for testing "standard" exceptions, where "standard" is defined as
+ * an exception class that is a subclass of {@link Exception} and contains the same four public constructors that
+ * do nothing but delegate to the superclass implementations. Any custom logic cannot be known in advanced, so only
+ * this "standard" behavior is tested here.
+ * <p>
+ * Example usage:
+ * <pre>
+ *    {@literal @}TestFactory
+ *     Collection&lt;DynamicTest&gt; shouldHaveStandardConstructors() {
+ *         return standardConstructorTestsFor(YourCustomException.class);
+ *     }
+ * </pre>
+ * JUnit will then execute all of the dynamic tests.
+ * <p>
+ * You can also use the methods that return a single {@link DynamicTest}.
+ */
+@UtilityClass
+public class StandardExceptionTests {
+
+    /**
+     * Generate a collection of dynamic tests that asserts a given class conforms to a "standard" exception
+     * containing the same four public constructor API as defined by {@link Exception}.
+     *
+     * @param exceptionClass the exception class
+     * @return dynamic tests for each of the four standard constructors
+     */
+    public static Collection<DynamicTest> standardConstructorTestsFor(Class<? extends Exception> exceptionClass) {
+        return List.of(
+                noArgConstructorDynamicTest(exceptionClass),
+                messageConstructorDynamicTest(exceptionClass),
+                messageAndCauseConstructorDynamicTest(exceptionClass),
+                causeConstructorDynamicTest(exceptionClass)
+        );
+    }
+
+    /**
+     * Generate a {@link DynamicTest} for a no-argument exception constructor.
+     *
+     * @param exceptionClass the exception class
+     * @return a dynamic test for a no-argument constructor
+     * @see Exception#Exception()
+     */
+    public static DynamicTest noArgConstructorDynamicTest(Class<? extends Exception> exceptionClass) {
+        var displayName = displayName(exceptionClass, "()");
+        return dynamicTest(displayName, () -> {
+            var exception = newInstanceUsingNoArgCtor(displayName, exceptionClass);
+
+            assertThat(exception)
+                    .isExactlyInstanceOf(exceptionClass)
+                    .hasMessage(null)
+                    .hasNoCause();
+        });
+    }
+
+    private static Exception newInstanceUsingNoArgCtor(String displayName,
+                                                       Class<? extends Exception> exceptionClass) {
+        try {
+            var constructor = exceptionClass.getConstructor();
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw newAssertionError(displayName, e);
+        }
+    }
+
+    /**
+     * Generate a {@link DynamicTest} for an exception constructor accepting a String message.
+     *
+     * @param exceptionClass the exception class
+     * @return a dynamic test for a constructor containing a message
+     * @see Exception#Exception(String)
+     */
+    public static DynamicTest messageConstructorDynamicTest(Class<? extends Exception> exceptionClass) {
+        var displayName = displayName(exceptionClass, "(String message)");
+        return dynamicTest(displayName, () -> {
+            var message = "An error occurred";
+            var exception = newInstanceUsingMessageCtor(displayName, exceptionClass, message);
+
+            assertThat(exception)
+                    .isExactlyInstanceOf(exceptionClass)
+                    .hasMessage(message)
+                    .hasNoCause();
+        });
+    }
+
+    private static Exception newInstanceUsingMessageCtor(String displayName,
+                                                         Class<? extends Exception> exceptionClass,
+                                                         String message) {
+        try {
+            var constructor = exceptionClass.getConstructor(String.class);
+            return constructor.newInstance(message);
+        } catch (Exception e) {
+            throw newAssertionError(displayName, e);
+        }
+    }
+
+    /**
+     * Generate a {@link DynamicTest} for an exception constructor accepting a String message and Throwable cause.
+     *
+     * @param exceptionClass the exception class
+     * @return a dynamic test for a constructor containing a message and cause
+     * @see Exception#Exception(String, Throwable)
+     */
+    public static DynamicTest messageAndCauseConstructorDynamicTest(Class<? extends Exception> exceptionClass) {
+        var displayName = displayName(exceptionClass, "(String message, Throwable cause)");
+        return dynamicTest(displayName, () -> {
+            var message = "An I/O related error occurred";
+            var cause = new IOException("I/O error");
+            var exception = newInstanceUsingMessageAndCauseCtor(displayName, exceptionClass, message, cause);
+
+            assertThat(exception)
+                    .isExactlyInstanceOf(exceptionClass)
+                    .hasMessage(message)
+                    .hasCause(cause);
+        });
+    }
+
+    private static Exception newInstanceUsingMessageAndCauseCtor(String displayName,
+                                                                 Class<? extends Exception> exceptionClass,
+                                                                 String message,
+                                                                 IOException cause) {
+        try {
+            var constructor = exceptionClass.getConstructor(String.class, Throwable.class);
+            return constructor.newInstance(message, cause);
+        } catch (Exception e) {
+            throw newAssertionError(displayName, e);
+        }
+    }
+
+    /**
+     * Generate a {@link DynamicTest} for an exception constructor accepting a Throwable cause.
+     *
+     * @param exceptionClass the exception class
+     * @return a dynamic test for a constructor containing a cause
+     * @see Exception#Exception(Throwable)
+     */
+    public static DynamicTest causeConstructorDynamicTest(Class<? extends Exception> exceptionClass) {
+        var displayName = displayName(exceptionClass, "(Throwable cause)");
+        return dynamicTest(displayName, () -> {
+            var cause = new IOException("An unexpected I/O error occurred");
+            var exception = newInstanceUsingCauseCtor(displayName, exceptionClass, cause);
+
+            assertThat(exception)
+                    .isExactlyInstanceOf(exceptionClass)
+                    .hasMessageContaining("IOException")
+                    .hasMessageContaining("An unexpected I/O error occurred")
+                    .hasCause(cause);
+        });
+    }
+
+    private static Exception newInstanceUsingCauseCtor(String displayName,
+                                                       Class<? extends Exception> exceptionClass,
+                                                       IOException cause) {
+        Exception exception;
+        try {
+            var constructor = exceptionClass.getConstructor(Throwable.class);
+            exception = constructor.newInstance(cause);
+        } catch (Exception e) {
+            throw newAssertionError(displayName, e);
+        }
+        return exception;
+    }
+
+    private static AssertionError newAssertionError(String displayName, Exception e) {
+        var errorMessage = f("Constructor '{}' failed. Cause: {}", displayName, e.getClass().getName());
+        return new AssertionError(errorMessage, e);
+    }
+
+    private static String displayName(Class<? extends Exception> exceptionClass, String parameterSpec) {
+        return exceptionClass.getSimpleName() + parameterSpec;
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/StandardExceptionTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/StandardExceptionTestsTest.java
@@ -1,0 +1,223 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.causeConstructorDynamicTest;
+import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.messageAndCauseConstructorDynamicTest;
+import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.messageConstructorDynamicTest;
+import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.noArgConstructorDynamicTest;
+import static org.kiwiproject.test.junit.jupiter.StandardExceptionTests.standardConstructorTestsFor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collection;
+
+@DisplayName("StandardExceptionTests")
+class StandardExceptionTestsTest {
+
+    /**
+     * This is actual usage as opposed to testing the {@link DynamicTest} instances directly, and we can only
+     * use an exception class that is "standard" otherwise the entire test fails.
+     */
+    @TestFactory
+    Collection<DynamicTest> shouldHaveStandardConstructors() {
+        return standardConstructorTestsFor(StandardException.class);
+    }
+
+    /**
+     * Actual usage. See explanation in {@link #shouldHaveStandardConstructors()}
+     */
+    @TestFactory
+    DynamicTest shouldHaveNoArgConstructor() {
+        return noArgConstructorDynamicTest(StandardException.class);
+    }
+
+    /**
+     * Actual usage. See explanation in {@link #shouldHaveStandardConstructors()}
+     */
+    @TestFactory
+    DynamicTest shouldHaveMessageConstructor() {
+        return messageConstructorDynamicTest(StandardException.class);
+    }
+
+    /**
+     * Actual usage. See explanation in {@link #shouldHaveStandardConstructors()}
+     */
+    @TestFactory
+    DynamicTest shouldHaveMessageAndCauseConstructor() {
+        return messageAndCauseConstructorDynamicTest(StandardException.class);
+    }
+
+    /**
+     * Actual usage. See explanation in {@link #shouldHaveStandardConstructors()}
+     */
+    @TestFactory
+    DynamicTest shouldHaveCauseConstructor() {
+        return causeConstructorDynamicTest(StandardException.class);
+    }
+
+    @Nested
+    class StandardConstructorTestsFor {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "StandardException()",
+                "StandardException(String message)",
+                "StandardException(String message, Throwable cause)",
+                "StandardException(Throwable cause)"
+        })
+        void shouldGenerateDynamicTests(String displayName) {
+            var dynamicTests = standardConstructorTestsFor(StandardException.class);
+            var test = findDynamicTest(dynamicTests, displayName);
+
+            assertThatCode(() -> execute(test)).doesNotThrowAnyException();
+        }
+
+        private DynamicTest findDynamicTest(Collection<DynamicTest> dynamicTests, String displayName) {
+            return dynamicTests.stream()
+                    .filter(dynamicTest -> dynamicTest.getDisplayName().equals(displayName))
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    @Nested
+    class NoArgConstructorDynamicTest {
+
+        @Test
+        void shouldPassWhenConstructorExists() {
+            var test = StandardExceptionTests.noArgConstructorDynamicTest(NonStandardException1.class);
+
+            assertThatCode(() -> execute(test)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFailWhenConstructorDoesNotExist() {
+            var test = StandardExceptionTests.noArgConstructorDynamicTest(NonStandardException2.class);
+            var executable = test.getExecutable();
+
+            assertThatThrownBy(executable::execute)
+                    .isExactlyInstanceOf(AssertionError.class)
+                    .hasMessage("Constructor 'NonStandardException2()' failed. Cause: java.lang.NoSuchMethodException")
+                    .hasCauseExactlyInstanceOf(NoSuchMethodException.class);
+        }
+    }
+
+    @Nested
+    class MessageConstructorDynamicTest {
+
+        @Test
+        void shouldPassWhenConstructorExists() {
+            var test = messageConstructorDynamicTest(NonStandardException2.class);
+
+            assertThatCode(() -> execute(test)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFailWhenConstructorDoesNotExist() {
+            var test = messageConstructorDynamicTest(NonStandardException1.class);
+            var executable = test.getExecutable();
+
+            assertThatThrownBy(executable::execute)
+                    .isExactlyInstanceOf(AssertionError.class)
+                    .hasMessage("Constructor 'NonStandardException1(String message)' failed. Cause: java.lang.NoSuchMethodException")
+                    .hasCauseExactlyInstanceOf(NoSuchMethodException.class);
+        }
+    }
+
+    @Nested
+    class MessageAndCauseConstructorDynamicTest {
+
+        @Test
+        void shouldPassWhenConstructorExists() {
+            var test = StandardExceptionTests.messageAndCauseConstructorDynamicTest(NonStandardException3.class);
+
+            assertThatCode(() -> execute(test)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFailWhenConstructorDoesNotExist() {
+            var test = StandardExceptionTests.messageAndCauseConstructorDynamicTest(NonStandardException2.class);
+            var executable = test.getExecutable();
+
+            assertThatThrownBy(executable::execute)
+                    .isExactlyInstanceOf(AssertionError.class)
+                    .hasMessage("Constructor 'NonStandardException2(String message, Throwable cause)' failed. Cause: java.lang.NoSuchMethodException")
+                    .hasCauseExactlyInstanceOf(NoSuchMethodException.class);
+        }
+    }
+
+    @Nested
+    class CauseConstructorDynamicTest {
+
+        @Test
+        void shouldPassWhenConstructorExists() {
+            var test = StandardExceptionTests.causeConstructorDynamicTest(NonStandardException4.class);
+
+            assertThatCode(() -> execute(test)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFailWhenConstructorDoesNotExist() {
+            var test = StandardExceptionTests.causeConstructorDynamicTest(NonStandardException2.class);
+            var executable = test.getExecutable();
+
+            assertThatThrownBy(executable::execute)
+                    .isExactlyInstanceOf(AssertionError.class)
+                    .hasMessage("Constructor 'NonStandardException2(Throwable cause)' failed. Cause: java.lang.NoSuchMethodException")
+                    .hasCauseExactlyInstanceOf(NoSuchMethodException.class);
+        }
+    }
+
+    private void execute(DynamicTest dynamicTest) {
+        try {
+            dynamicTest.getExecutable().execute();
+        } catch (Throwable throwable) {
+            throw new RuntimeException(dynamicTest.getDisplayName(), throwable);
+        }
+    }
+
+    public static class StandardException extends RuntimeException {
+        public StandardException() {
+        }
+
+        public StandardException(String message) {
+            super(message);
+        }
+
+        public StandardException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public StandardException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    public static class NonStandardException1 extends Exception {
+    }
+
+    public static class NonStandardException2 extends Exception {
+        public NonStandardException2(String message) {
+            super(message);
+        }
+    }
+
+    public static final class NonStandardException3 extends Exception {
+        public NonStandardException3(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static final class NonStandardException4 extends Exception {
+        public NonStandardException4(Throwable cause) {
+            super(cause);
+        }
+    }
+}


### PR DESCRIPTION
Migrate and enhance StandardExceptionTests from dropwizard-curator.
The enhanced version throws AssertionError if the constructor
under test cannot be found or instantiated, as opposed to just throwing
the raw cause. It also provides a consistent and more useful error
message including the constructor signature.

Fixes #90