### PR TITLE
Add JUnit Jupiter blank string argument providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>${jsonassert.version}</version>

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
@@ -1,0 +1,72 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static java.util.Collections.unmodifiableList;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Creates an {@link ArgumentsProvider} that can feed a test method with multiple blank {@link String} objects for a
+ * {@link org.junit.jupiter.params.ParameterizedTest ParameterizedTest}. This will generate a {@code null} String
+ * argument, an empty String argument, a String with multiple spaces, and a String with whitespace characters.
+ * <p>
+ * <strong></b>However</strong>, unlike {@link BlankStringArgumentsProvider}, this will only use characters that fall
+ * in the ASCII character set. Unless it is absolutely necessary to test against ASCII only whitespace (for example, to
+ * validate using the Bean Validation API's {@link javax.validation.constraints.NotBlank NotBlank} annotation), it is
+ * recommended you use {@link BlankStringArgumentsProvider} instead.
+ * <p>
+ * Usage:
+ * <pre>
+ * {@literal @}ParameterizedTest
+ * {@literal @}ArgumentsSource(AsciiOnlyBlankStringArgumentsProvider.class)
+ *  void testThatEachProvidedArgumentIsBlank(String blankString) {
+ *      assertThat(blankString).isBlank();
+ *      // or whatever else you need to test where you need a blank String...
+ *  }
+ * </pre>
+ *
+ * @see BlankStringArgumentsProvider
+ */
+public class AsciiOnlyBlankStringArgumentsProvider implements ArgumentsProvider {
+
+    /**
+     * A bunch of null, empty, or blank ASCII Strings.
+     */
+    public static final List<String> ASCII_ONLY_BLANK_STRINGS = unmodifiableList(Arrays.asList(
+            // null, empty, blank space-only
+            null,
+            "",
+            " ",
+            "    ",
+
+            // ASCII characters
+            "\t", // HORIZONTAL TABULATION (U+0009)
+            "\n", // LINE FEED (U+000A)
+            "\u000B", // VERTICAL TABULATION
+            "\f", // FORM FEED (U+000C)
+            "\r", // CARRIAGE RETURN (U+000D)
+            "\u001C", // FILE SEPARATOR
+            "\u001D", // GROUP SEPARATOR
+            "\u001E", // RECORD SEPARATOR
+            "\u001F" // UNIT SEPARATOR
+    ));
+
+    /**
+     * Provides various blank arguments for {@link org.junit.jupiter.params.ParameterizedTest ParameterizedTest} tests.
+     *
+     * @param context the extension context
+     * @return a {@link Stream} of blank String {@link Arguments}
+     * @implNote The stream must be instantiated for each test. If you try to extract these fields out to a constant,
+     * any test class that uses this {@link ArgumentsProvider} more than once will fail due to the stream being
+     * exhausted. So don't do that.
+     */
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return ASCII_ONLY_BLANK_STRINGS.stream().map(Arguments::of);
+    }
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProvider.java
@@ -1,0 +1,102 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static java.util.Collections.unmodifiableList;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Creates an {@link ArgumentsProvider} that can feed a test method with multiple blank {@link String} objects for a
+ * {@link org.junit.jupiter.params.ParameterizedTest ParameterizedTest}. This will generate a {@code null} String
+ * argument, an empty String argument, a String with multiple spaces, and a String with whitespace characters.
+ * <p>
+ * Usage:
+ * <pre>
+ * {@literal @}ParameterizedTest
+ * {@literal @}ArgumentsSource(BlankStringArgumentsProvider.class)
+ *  void testThatEachProvidedArgumentIsBlank(String blankString) 1
+ *      assertThat(blankString).isBlank();
+ *      // or whatever else you need to test where you need a blank String...
+ *  }
+ * </pre>
+ *
+ * @see AsciiOnlyBlankStringArgumentsProvider
+ */
+public class BlankStringArgumentsProvider implements ArgumentsProvider {
+
+    /**
+     * A bunch of null, empty, or blank Strings.
+     */
+    public static final List<String> BLANK_STRINGS = unmodifiableList(Arrays.asList(
+            // null, empty, blank space-only
+            null,
+            "",
+            " ",
+            "    ",
+
+            // ASCII characters
+            "\t", // HORIZONTAL TABULATION (U+0009)
+            "\n", // LINE FEED (U+000A)
+            "\u000B", // VERTICAL TABULATION
+            "\f", // FORM FEED (U+000C)
+            "\r", // CARRIAGE RETURN (U+000D)
+            "\u001C", // FILE SEPARATOR
+            "\u001D", // GROUP SEPARATOR
+            "\u001E", // RECORD SEPARATOR
+            "\u001F", // UNIT SEPARATOR
+
+            // SPACE SEPARATOR characters (general category "Zs" of the Unicode specification)
+            " ", // SPACE (U+0020
+            // U+00A0 (NO-BREAK SPACE) is explicitly **NOT** considered whitespace per Character JavaDocs
+            "\u1680", // OGHAM SPACE MARK
+            "\u2000", // EN QUAD
+            "\u2001", // EM QUAD
+            "\u2002", // EN SPACE
+            "\u2003", // EM SPACE
+            "\u2004", // THREE-PER-EM SPACE
+            "\u2005", // FOUR-PER-EM SPACE
+            "\u2006", // SIX-PER-EM SPACE
+            // U+2007 (FIGURE SPACE) is explicitly **NOT** considered whitespace per Character JavaDocs
+            "\u2008", // PUNCTUATION SPACE
+            "\u2009", // THIN SPACE
+            "\u200A", // HAIR SPACE
+            // U+202F (NARROW NO-BREAK-SPACE) is explicitly **NOT** considered whitespace per Character JavaDocs
+            "\u205F", // MEDIUM MATHEMATICAL SPACE
+            "\u3000", // IDEOGRAPHIC SPACE
+
+            // LINE SEPARATOR characters (general category "Zl" of the Unicode specification)
+            "\u2028", // LINE SEPARATOR
+
+            // PARAGRAPH SEPARATOR characters (general category "Zp" Unicode specification)
+            "\u2029", // PARAGRAPH SEPARATOR
+
+            // Multiple character tests
+            // ASCII chars
+            "\t \n \u000B \f \r \u001C \u001D \u001E \u001F",
+
+            // SPACE_SEPARATOR chars
+            "\u1680 \u2000 \u2001 \u2002 \u2003 \u2004 \u2005 \u2006 \u2008 \u2009 \u205F \u3000",
+
+            // LINE SEPARATOR & PARAGRAPH SEPARATOR chars
+            "\u2028 \u2029"
+    ));
+
+    /**
+     * Provides various blank arguments for {@link org.junit.jupiter.params.ParameterizedTest ParameterizedTest} tests.
+     *
+     * @param context the extension context
+     * @return a {@link Stream} of blank String {@link Arguments}
+     * @implNote The stream must be instantiated for each test. If you try to extract these fields out to a constant,
+     * any test class that uses this {@link ArgumentsProvider} more than once will fail due to the stream being
+     * exhausted. So don't do that.
+     */
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return BLANK_STRINGS.stream().map(Arguments::of);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProviderTest.java
@@ -1,0 +1,29 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@DisplayName("AsciiOnlyBlankStringArgumentsProvider")
+class AsciiOnlyBlankStringArgumentsProviderTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(AsciiOnlyBlankStringArgumentsProvider.class)
+    void testThatEachProvidedArgumentIsBlank(String blankString) {
+        assertThat(blankString).isBlank();
+
+        if (nonNull(blankString)) {
+            assertOnlyAsciiCharactersIn(blankString);
+        }
+    }
+
+    private static void assertOnlyAsciiCharactersIn(String blankString) {
+        blankString.chars().forEach(charValue ->
+                assertThat(charValue)
+                        .describedAs("char %d not less than 255", charValue)
+                        .isLessThanOrEqualTo(0xFF));
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProviderTest.java
@@ -1,0 +1,17 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@DisplayName("BlankStringArgumentsProvider")
+class BlankStringArgumentsProviderTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    void testThatEachProvidedArgumentIsBlank(String blankString) {
+        assertThat(blankString).isBlank();
+    }
+}


### PR DESCRIPTION
* Add AsciiOnlyBlankStringArgumentsProvider
* Add BlankStringArgumentsProvider
* Add junit-jupiter-params dependency and define scope as provided,
  since in this testing library it is not just for test code!

Fixes #99
Fixes #100