### PR TITLE
Add H2FileBasedDatabaseExtension and accompanying H2Database annotation

### DIFF
--- a/src/main/java/org/kiwiproject/test/h2/H2DatabaseTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/h2/H2DatabaseTestHelper.java
@@ -69,7 +69,7 @@ public class H2DatabaseTestHelper {
     @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
     private static DataSource buildH2DatabaseWithTestTable(File h2DatabaseDirectory) {
         var url = getDatabaseUrl(h2DatabaseDirectory);
-        LOG.info("Create test database with URL: {}", url);
+        LOG.trace("Create test database with URL: {}", url);
 
         var dataSource = new JdbcDataSource();
         dataSource.setURL(url);
@@ -78,7 +78,7 @@ public class H2DatabaseTestHelper {
              var ps = conn.prepareStatement("create table test_table (first varchar , second integer)")
         ) {
             ps.execute();
-            LOG.info("Successfully created test_table");
+            LOG.trace("Successfully created test_table");
             return dataSource;
         } catch (SQLException e) {
             throw new RuntimeSQLException(e);

--- a/src/main/java/org/kiwiproject/test/h2/H2FileBasedDatabase.java
+++ b/src/main/java/org/kiwiproject/test/h2/H2FileBasedDatabase.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.h2;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import javax.sql.DataSource;
 import java.io.File;
@@ -14,6 +15,7 @@ import java.io.File;
  */
 @AllArgsConstructor
 @Getter
+@ToString(of = {"directory", "url"})
 public class H2FileBasedDatabase {
     private final File directory;
     private final String url;

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2Database.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2Database.java
@@ -1,0 +1,15 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link H2Database} can be used to annotate a parameter of type {@link org.kiwiproject.test.h2.H2FileBasedDatabase}
+ * in lifecycle or test methods.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface H2Database {
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -1,0 +1,128 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import lombok.Getter;
+import lombok.experimental.Delegate;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.kiwiproject.test.h2.H2DatabaseTestHelper;
+import org.kiwiproject.test.h2.H2FileBasedDatabase;
+
+/**
+ * JUnit Jupiter extension that creates a file-based H2 database before all tests and deletes it after all tests
+ * have executed. It also provides for injection of the database into test lifecycle methods that declare
+ * a {@link H2FileBasedDatabase} annotated with {@link H2Database}.
+ * <p>
+ * You can register the extension via {@code ExtendWith} and then use parameter resolution with the {@link H2Database}
+ * annotation to obtain the {@link H2FileBasedDatabase} instance in a lifecycle or test method. Example:
+ * <pre>
+ * {@literal @}ExtendWith(H2FileBasedDatabaseExtension.class)
+ *  class MyFirstTest {
+ *
+ *     {@literal @}BeforeEach
+ *      void setUp(@H2Database H2FileBasedDatabase database) { ... }
+ *
+ *     {@literal @}Test
+ *      void shouldDoSomethingWithTheDatabase(@H2Database H2FileBasedDatabase database) { ... }
+ *  }
+ * </pre>
+ * <p>
+ * Alternatively, if you need to supply another extension with the H2 database, then you can register the extension
+ * on a static field using {@code @RegisterExtension}. Here is an example using a theoretical extension named
+ * {@code DaoExtension} that requires a {@code DataSource}. The data source is obtained from the
+ * {@link H2FileBasedDatabase} provided by this extension:
+ * <pre>
+ * class MySecondTest {
+ *
+ *    {@literal @}RegisterExtension
+ *     static H2FileBasedDatabaseExtension databaseExtension = new H2FileBasedDatabaseExtension();
+ *
+ *    {@literal @}RegisterExtension
+ *     final DaoExtension&lt;PersonDao&gt; jdbi3DaoExtension =
+ *             DaoExtension.&lt;PersonDao&gt;builder()
+ *                     .daoType(PersonDao.class)
+ *                     .dataSource(databaseExtension.getDataSource())  // supply the DataSource here
+ *                     .plugin(new H2DatabasePlugin())
+ *                     .build();
+ * }
+ * </pre>
+ * <strong>NOTE:</strong>The second example only works when the extension that requires the {@link H2FileBasedDatabase}
+ * is an <em>instance</em> field. If it is static, it will not work!
+ * <p>
+ * When using this extension via {@code @RegisterExtension}, you can use the getter methods to retrieve the entire
+ * {@link H2FileBasedDatabase} object or its individual properties. When using it with {@code @ExtendWith} and an
+ * injected parameter, you obviously have direct access to the {@link H2FileBasedDatabase} object.
+ */
+@Slf4j
+public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+
+    private static final String DATABASE_KEY = "database";
+
+    @Getter
+    @Delegate
+    private H2FileBasedDatabase database;
+
+    /**
+     * Creates a new H2 file-based database.
+     *
+     * @param context extension context
+     */
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        database = H2DatabaseTestHelper.buildH2FileBasedDatabase();
+        LOG.trace("Created database: {}", database);
+
+        var namespace = createNamespace();
+        context.getStore(namespace).put(DATABASE_KEY, database);
+    }
+
+    /**
+     * Deletes the H2 file-based database.
+     *
+     * @param context extension context
+     * @throws Exception if the database directory could not be deleted
+     */
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        LOG.trace("Deleting database: {}", database);
+        FileUtils.deleteDirectory(database.getDirectory());
+    }
+
+    /**
+     * Does the parameter need to be resolved?
+     *
+     * @param parameterContext parameter context
+     * @param extensionContext extension context
+     * @return true if the {@code parameterContext} is annotated with {@link H2Database}
+     */
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.isAnnotated(H2Database.class);
+    }
+
+    /**
+     * Resolve the parameter annotated with {@link H2Database} into a {@link H2FileBasedDatabase}.
+     *
+     * @param parameterContext parameter context
+     * @param extensionContext extension context
+     * @return the resolved {@link H2FileBasedDatabase}
+     */
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        var namespace = createNamespace();
+
+        return getDatabase(extensionContext, namespace);
+    }
+
+    private ExtensionContext.Namespace createNamespace() {
+        return ExtensionContext.Namespace.create(getClass(), "H2FileBasedDatabase", Thread.currentThread().getName());
+    }
+
+    private H2FileBasedDatabase getDatabase(ExtensionContext context, ExtensionContext.Namespace namespace) {
+        return context.getStore(namespace).get(DATABASE_KEY, H2FileBasedDatabase.class);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2DatabaseTestExtension.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2DatabaseTestExtension.java
@@ -1,0 +1,32 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.h2.H2FileBasedDatabase;
+
+/**
+ * A JUnit Jupiter extension solely for testing the {@link H2FileBasedDatabaseExtension}.
+ * <p>
+ * It requires a {@link H2FileBasedDatabase} and does nothing except log database information.
+ */
+@AllArgsConstructor
+@Slf4j
+public class H2DatabaseTestExtension implements BeforeEachCallback, AfterEachCallback {
+
+    @Getter
+    private final H2FileBasedDatabase database;
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        LOG.debug("Database in beforeEach: {}", database);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        LOG.debug("Database in afterEach: {}", database);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
@@ -1,0 +1,81 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.test.h2.H2FileBasedDatabase;
+
+import java.sql.SQLException;
+
+/**
+ * Test of {@link H2FileBasedDatabaseExtension} using {@code ExtendWith}.
+ */
+@DisplayName("H2FileBasedDatabaseExtension using @ExtendWith")
+@ExtendWith(H2FileBasedDatabaseExtension.class)
+@Slf4j
+class H2FileBasedDatabaseExtensionExtendWithTest {
+
+    private H2FileBasedDatabase databaseFromSetup;
+
+    @BeforeEach
+    void setUp(@H2Database H2FileBasedDatabase database) {
+        this.databaseFromSetup = database;
+    }
+
+    @Test
+    void shouldProvideDatabaseInTestMethod(@H2Database H2FileBasedDatabase database) {
+        assertThat(database).isNotNull();
+    }
+
+    @Test
+    void shouldProvideDatabaseInLifecycleMethod(@H2Database H2FileBasedDatabase database) {
+        assertThat(databaseFromSetup)
+                .isNotNull()
+                .isSameAs(database);
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    @Test
+    void shouldBeAbleToConnectToDatabase(@H2Database H2FileBasedDatabase database) throws SQLException {
+        try (var conn = database.getDataSource().getConnection();
+             var stmt = conn.createStatement();
+             var rs = stmt.executeQuery("select count(*) as count from test_table")) {
+
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt("count")).isZero();
+        }
+    }
+
+    @Nested
+    class NestedTestClass {
+
+        private H2FileBasedDatabase databaseFromNestedSetup;
+
+        @BeforeEach
+        void setUp(@H2Database H2FileBasedDatabase database) {
+            this.databaseFromNestedSetup = database;
+        }
+
+        @Test
+        void shouldProvideDatabaseInNestedTestMethod(@H2Database H2FileBasedDatabase database) {
+            assertThat(database).isNotNull();
+        }
+
+        @Test
+        void shouldProvideDatabaseInNestedClassLifecycleMethod(@H2Database H2FileBasedDatabase database) {
+            assertThat(databaseFromNestedSetup)
+                    .isNotNull()
+                    .isSameAs(database);
+        }
+
+        @Test
+        void shouldHaveSameDatabaseForNestedAndParentSetup() {
+            assertThat(databaseFromNestedSetup).isSameAs(databaseFromSetup);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
@@ -1,0 +1,48 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.h2.H2FileBasedDatabase;
+
+import java.sql.SQLException;
+
+/**
+ * Test of {@link H2FileBasedDatabaseExtension} using {@code RegisterExtension}.
+ */
+@DisplayName("H2FileBasedDatabaseExtension using @RegisterExtension")
+class H2FileBasedDatabaseExtensionRegisterTest {
+
+    @RegisterExtension
+    static H2FileBasedDatabaseExtension databaseExtension = new H2FileBasedDatabaseExtension();
+
+    @RegisterExtension
+    final H2DatabaseTestExtension testExtension = new H2DatabaseTestExtension(databaseExtension.getDatabase());
+
+    @Test
+    void shouldMakeDatabaseAvailableToTests() {
+        assertThat(databaseExtension.getDatabase()).isNotNull();
+        assertThat(databaseExtension.getUrl()).isNotBlank();
+        assertThat(databaseExtension.getDirectory()).isNotNull();
+        assertThat(databaseExtension.getDataSource()).isNotNull();
+    }
+
+    @Test
+    void shouldSupplyDatabaseToTestExtension() {
+        assertThat(testExtension.getDatabase()).isSameAs(databaseExtension.getDatabase());
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    @Test
+    void shouldBeAbleToConnectToDatabase(@H2Database H2FileBasedDatabase database) throws SQLException {
+        try (var conn = database.getDataSource().getConnection();
+             var stmt = conn.createStatement();
+             var rs = stmt.executeQuery("select count(*) as count from test_table")) {
+
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt("count")).isZero();
+        }
+    }
+}


### PR DESCRIPTION
* Add Jupiter extension H2FileBasedDatabaseExtension
* Add two tests for H2FileBasedDatabaseExtension: one to test usage
  with @ExtendWith, and another to test usage with @RegisterExtension
* Add H2Database annotation for parameter resolution

Misc:
* Change logging in H2DatabaseTestHelper from INFO to TRACE level; there
  is no need to see that information at such a high log level
* Add @ToString to H2FileBasedDatabase that includes directory and url

Fixes #118