### PR TITLE
Rename JDBI 3 JUnit Jupiter extensions without Dropwizard in the name

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtension.java
@@ -2,8 +2,8 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static java.util.Objects.isNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
-import static org.kiwiproject.test.junit.jupiter.DropwizardJdbi3Helpers.buildJdbi;
-import static org.kiwiproject.test.junit.jupiter.DropwizardJdbi3Helpers.configureSqlLogger;
+import static org.kiwiproject.test.junit.jupiter.Jdbi3Helpers.buildJdbi;
+import static org.kiwiproject.test.junit.jupiter.Jdbi3Helpers.configureSqlLogger;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -23,10 +23,10 @@ import java.util.List;
 
 /**
  * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to easily test JDBI 3-based DAOs in
- * a Dropwizard app against any database and using transaction rollback to make sure tests never commit to the database.
+ * against any database and using transaction rollback to make sure tests never commit to the database.
  * <p>
  * You must supply the {@code daoType} and one of three methods for obtaining a database {@link Connection}:
- * (1) a {@link DataSource}, (2) a Dropwizard {@link ConnectionFactory}, or
+ * (1) a {@link DataSource}, (2) a JDBI {@link ConnectionFactory}, or
  * (3) the JDBC URL, username, and password.
  * <p>
  * Before each tests, sets up a transaction. After each test completes, rolls the transaction back.
@@ -37,7 +37,7 @@ import java.util.List;
  * @param <T> the DAO type
  */
 @Slf4j
-public class DropwizardJdbi3DaoExtension<T> implements BeforeEachCallback, AfterEachCallback {
+public class Jdbi3DaoExtension<T> implements BeforeEachCallback, AfterEachCallback {
 
     /**
      * The type of DAO (<em>required</em>)
@@ -91,16 +91,16 @@ public class DropwizardJdbi3DaoExtension<T> implements BeforeEachCallback, After
      */
     @SuppressWarnings("java:S107") // builder-annotated constructors are an exception to the "too many parameters" rule
     @Builder
-    private DropwizardJdbi3DaoExtension(String url,
-                                        String username,
-                                        String password,
-                                        ConnectionFactory connectionFactory,
-                                        DataSource dataSource,
-                                        String slf4jLoggerName,
-                                        Class<T> daoType,
-                                        @Singular List<JdbiPlugin> plugins) {
+    private Jdbi3DaoExtension(String url,
+                              String username,
+                              String password,
+                              ConnectionFactory connectionFactory,
+                              DataSource dataSource,
+                              String slf4jLoggerName,
+                              Class<T> daoType,
+                              @Singular List<JdbiPlugin> plugins) {
 
-        LOG.trace("A new {} is being instantiated", DropwizardJdbi3DaoExtension.class.getSimpleName());
+        LOG.trace("A new {} is being instantiated", Jdbi3DaoExtension.class.getSimpleName());
 
         this.daoType = requireNotNull(daoType, "Must specify the DAO type");
 
@@ -146,6 +146,6 @@ public class DropwizardJdbi3DaoExtension<T> implements BeforeEachCallback, After
      */
     @Override
     public void afterEach(ExtensionContext context) {
-        DropwizardJdbi3Helpers.rollbackAndClose(handle, LOG);
+        Jdbi3Helpers.rollbackAndClose(handle, LOG);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Extension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Extension.java
@@ -1,8 +1,8 @@
 package org.kiwiproject.test.junit.jupiter;
 
 import static java.util.Objects.isNull;
-import static org.kiwiproject.test.junit.jupiter.DropwizardJdbi3Helpers.buildJdbi;
-import static org.kiwiproject.test.junit.jupiter.DropwizardJdbi3Helpers.configureSqlLogger;
+import static org.kiwiproject.test.junit.jupiter.Jdbi3Helpers.buildJdbi;
+import static org.kiwiproject.test.junit.jupiter.Jdbi3Helpers.configureSqlLogger;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -22,11 +22,11 @@ import java.util.List;
 
 /**
  * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to easily test JDBI 3 DAOs using the
- * "Fluent API" (as opposed to the SQL Objects API) in a Dropwizard app against any database and using transaction
- * rollback to make sure tests never commit to the database.
+ * "Fluent API" (as opposed to the SQL Objects API) against any database and using transaction rollback to make sure
+ * tests never commit to the database.
  * <p>
  * You must supply one of three methods for obtaining a database {@link Connection}:
- * (1) a {@link DataSource}, (2) a Dropwizard {@link ConnectionFactory}, or
+ * (1) a {@link DataSource}, (2) a JDBI {@link ConnectionFactory}, or
  * (3) the JDBC URL, username, and password.
  * <p>
  * Before each tests, sets up a transaction. After each test completes, rolls the transaction back.
@@ -36,7 +36,7 @@ import java.util.List;
  * provided by this extension.</strong>
  */
 @Slf4j
-public class DropwizardJdbi3Extension implements BeforeEachCallback, AfterEachCallback {
+public class Jdbi3Extension implements BeforeEachCallback, AfterEachCallback {
 
     /**
      * The {@link Jdbi} instance created by this extension. You can pass this to DAOs that use {@link Jdbi} directly
@@ -73,15 +73,15 @@ public class DropwizardJdbi3Extension implements BeforeEachCallback, AfterEachCa
      */
     @SuppressWarnings("java:S107") // builder-annotated constructors are an exception to the "too many parameters" rule
     @Builder
-    private DropwizardJdbi3Extension(String url,
-                                     String username,
-                                     String password,
-                                     ConnectionFactory connectionFactory,
-                                     DataSource dataSource,
-                                     String slf4jLoggerName,
-                                     @Singular List<JdbiPlugin> plugins) {
+    private Jdbi3Extension(String url,
+                           String username,
+                           String password,
+                           ConnectionFactory connectionFactory,
+                           DataSource dataSource,
+                           String slf4jLoggerName,
+                           @Singular List<JdbiPlugin> plugins) {
 
-        LOG.trace("A new {} is being instantiated", DropwizardJdbi3Extension.class.getSimpleName());
+        LOG.trace("A new {} is being instantiated", Jdbi3Extension.class.getSimpleName());
 
         var nonNullPlugins = isNull(plugins) ? List.<JdbiPlugin>of() : plugins;
         this.jdbi = buildJdbi(dataSource, connectionFactory, url, username, password, nonNullPlugins);
@@ -120,6 +120,6 @@ public class DropwizardJdbi3Extension implements BeforeEachCallback, AfterEachCa
      */
     @Override
     public void afterEach(ExtensionContext context) {
-        DropwizardJdbi3Helpers.rollbackAndClose(handle, LOG);
+        Jdbi3Helpers.rollbackAndClose(handle, LOG);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Helpers.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Helpers.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 @UtilityClass
 @Slf4j
-public class DropwizardJdbi3Helpers {
+public class Jdbi3Helpers {
 
     static Jdbi buildJdbi(DataSource dataSource,
                           ConnectionFactory connectionFactory,
@@ -41,7 +41,7 @@ public class DropwizardJdbi3Helpers {
         jdbi.installPlugin(new SqlObjectPlugin());
 
         plugins.stream()
-                .filter(not(DropwizardJdbi3Helpers::isSqlObjectPlugin))
+                .filter(not(Jdbi3Helpers::isSqlObjectPlugin))
                 .forEach(jdbi::installPlugin);
 
         return jdbi;

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtensionTest.java
@@ -9,6 +9,8 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.h2.H2DatabasePlugin;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,19 +29,20 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
-@DisplayName("DropwizardJdbi3Extension")
+@DisplayName("Jdbi3DaoExtension")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Slf4j
 @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
-class DropwizardJdbi3ExtensionTest {
+class Jdbi3DaoExtensionTest {
 
     private static H2FileBasedDatabase database;
 
     @RegisterExtension
-    final DropwizardJdbi3Extension jdbi3Extension =
-            DropwizardJdbi3Extension.builder()
+    final Jdbi3DaoExtension<TestTableDao> jdbi3DaoExtension =
+            Jdbi3DaoExtension.<TestTableDao>builder()
+                    .daoType(TestTableDao.class)
                     .dataSource(database.getDataSource())
-                    .slf4jLoggerName(DropwizardJdbi3ExtensionTest.class.getName())
+                    .slf4jLoggerName(Jdbi3DaoExtensionTest.class.getName())
                     .plugin(new H2DatabasePlugin())
                     .build();
 
@@ -54,8 +57,8 @@ class DropwizardJdbi3ExtensionTest {
     @BeforeEach
     void setUp(TestInfo testInfo) {
         LOG.trace("Executing test: {}", testInfo.getDisplayName());
-        handle = jdbi3Extension.getHandle();
-        dao = new TestTableDao();
+        handle = jdbi3DaoExtension.getHandle();
+        dao = jdbi3DaoExtension.getDao();
     }
 
     @AfterAll
@@ -73,7 +76,7 @@ class DropwizardJdbi3ExtensionTest {
     @Test
     @Order(2)
     void findAllValues_ShouldNotSeeAnyDataBeforeTestDataInserted() {
-        var values = dao.findAll(handle);
+        var values = dao.findAll();
         assertThat(values).isEmpty();
     }
 
@@ -84,22 +87,24 @@ class DropwizardJdbi3ExtensionTest {
         handle.execute("insert into test_table values ('Scott', 44)");
         handle.execute("insert into test_table values ('Han', 45)");
         handle.execute("insert into test_table values ('Tony', 50)");
-        var values = dao.findAll(handle);
+        var values = dao.findAll();
         assertThat(values).hasSize(4);
     }
 
     @Test
     @Order(4)
     void findAllValues_ShouldNotSeeAnyDataFromPreviousTest() {
-        var values = dao.findAll(handle);
+        var values = dao.findAll();
         assertThat(values).isEmpty();
     }
 
     @Test
     @Order(5)
     void shouldSetProperties() {
-        assertThat(jdbi3Extension.getJdbi()).isNotNull();
-        assertThat(jdbi3Extension.getHandle()).isNotNull();
+        assertThat(jdbi3DaoExtension.getDaoType()).isEqualTo(TestTableDao.class);
+        assertThat(jdbi3DaoExtension.getJdbi()).isNotNull();
+        assertThat(jdbi3DaoExtension.getHandle()).isNotNull();
+        assertThat(jdbi3DaoExtension.getDao()).isNotNull();
     }
 
     @Value
@@ -108,24 +113,17 @@ class DropwizardJdbi3ExtensionTest {
         int second;
     }
 
-    private static class TestTableValueMapper implements RowMapper<TestTableValue> {
+    // Must be public for JDBI to instantiate
+    public static class TestTableValueMapper implements RowMapper<TestTableValue> {
         @Override
         public TestTableValue map(ResultSet rs, StatementContext ctx) throws SQLException {
-            return new TestTableValue(rs.getString("first"),
-                    rs.getInt("second"));
+            return new TestTableValue(rs.getString("first"), rs.getInt("second"));
         }
     }
 
-    private static class TestTableDao {
-
-        /**
-         * @implNote We need the same exact {@link Handle} to be used in the tests to ensure we get the same
-         * SQL {@code Connection}, otherwise you run into transaction isolation issues.
-         */
-        List<TestTableValue> findAll(Handle handle) {
-            return handle.createQuery("select * from test_table")
-                    .map(new TestTableValueMapper())
-                    .list();
-        }
+    @RegisterRowMapper(TestTableValueMapper.class)
+    private interface TestTableDao {
+        @SqlQuery("select * from test_table")
+        List<TestTableValue> findAll();
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3HelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3HelpersTest.java
@@ -25,9 +25,9 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
-@DisplayName("DropwizardJdbi3Helpers")
+@DisplayName("Jdbi3Helpers")
 @Slf4j
-class DropwizardJdbi3HelpersTest {
+class Jdbi3HelpersTest {
 
     private static H2FileBasedDatabase database;
 
@@ -49,20 +49,20 @@ class DropwizardJdbi3HelpersTest {
         @Test
         void shouldThrow_WhenNoArgumentsProvided() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> DropwizardJdbi3Helpers.buildJdbi(null, null, null, null, null, List.of()));
+                    .isThrownBy(() -> Jdbi3Helpers.buildJdbi(null, null, null, null, null, List.of()));
         }
 
         @Test
         void shouldAcceptConnectionFactory() {
             var connectionFactory = new DataSourceConnectionFactory(database.getDataSource());
-            var jdbi = DropwizardJdbi3Helpers.buildJdbi(null, connectionFactory, null, null, null, List.of());
+            var jdbi = Jdbi3Helpers.buildJdbi(null, connectionFactory, null, null, null, List.of());
             assertThat(jdbi).isNotNull();
             assertCanExecuteQuery(jdbi);
         }
 
         @Test
         void shouldAcceptJdbcConnectionProperties() {
-            var jdbi = DropwizardJdbi3Helpers.buildJdbi(null, null, database.getUrl(), "", "", List.of());
+            var jdbi = Jdbi3Helpers.buildJdbi(null, null, database.getUrl(), "", "", List.of());
             assertThat(jdbi).isNotNull();
             assertCanExecuteQuery(jdbi);
         }
@@ -91,7 +91,7 @@ class DropwizardJdbi3HelpersTest {
 
         @Test
         void shouldUseDefaultLoggerName_WhenGivenBlankLoggerName() {
-            var jdbiSqlLogger = DropwizardJdbi3Helpers.configureSqlLogger(jdbi, "");
+            var jdbiSqlLogger = Jdbi3Helpers.configureSqlLogger(jdbi, "");
             assertThat(jdbiSqlLogger.getLoggerName()).isEqualTo(Jdbi.class.getName());
 
             verify(jdbi).setSqlLogger(jdbiSqlLogger);
@@ -100,7 +100,7 @@ class DropwizardJdbi3HelpersTest {
         @Test
         void shouldUseGivenLoggerName() {
             var loggerName = "My Jdbi Logger";
-            var jdbiSqlLogger = DropwizardJdbi3Helpers.configureSqlLogger(jdbi, loggerName);
+            var jdbiSqlLogger = Jdbi3Helpers.configureSqlLogger(jdbi, loggerName);
             assertThat(jdbiSqlLogger.getLoggerName()).isEqualTo(loggerName);
 
             verify(jdbi).setSqlLogger(jdbiSqlLogger);


### PR DESCRIPTION
The JDBI 3 Jupiter extensions have Dropwizard in their names but,
unlike the JDBI 2 extensions, they are independent of Dropwizard
and therefore can be renamed.

* DropwizardJdbi3DaoExtension -> Jdbi3DaoExtension
* DropwizardJdbi3Extension -> Jdbi3Extension
* DropwizardJdbi3Helpers -> Jdbi3Helpers

Fixes #117