### PR TITLE
Add MongoDbExtension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <jsonassert.version>1.5.0</jsonassert.version>
         <liquibase.version>3.8.9</liquibase.version>
         <mongo-java-driver.version>3.10.1</mongo-java-driver.version>
+        <mongo-java-server.version>1.36.0</mongo-java-server.version>
         <zookeeper.version>3.4.14</zookeeper.version>
 
         <!-- Versions for optional dependencies -->
@@ -458,7 +459,12 @@
 
         <!-- test dependencies -->
 
-        <!-- nothing here yet...move along... -->
+        <dependency>
+            <groupId>de.bwaldvogel</groupId>
+            <artifactId>mongo-java-server</artifactId>
+            <version>${mongo-java-server.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
@@ -3,6 +3,7 @@ package org.kiwiproject.test.junit.jupiter;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.MongoClient;
@@ -148,7 +149,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
         this.dropTime = isNull(dropTime) ? DropTime.AFTER_ALL : dropTime;
         this.cleanupOption = isNull(cleanupOption) ? CleanupOption.REMOVE_RECORDS : cleanupOption;
         this.skipCleanup = skipCleanup;
-        this.props = props;
+        this.props = requireNotNull(props);
         this.mongo = props.newMongoClient();
         this.databaseName = props.getDatabaseName();
         this.mongoUri = props.getUri();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
@@ -1,0 +1,238 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toList;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.test.mongo.MongoTestProperties.UNIT_TEST_ID;
+import static org.kiwiproject.test.mongo.MongoTestProperties.UNIT_TEST_ID_SHORT;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Consumer;
+
+/**
+ * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to use in Mongo unit/integration tests.
+ * This extension by default drops the test Mongo database after <em>all</em> tests have run but clears records from
+ * collections after <em>each</em> test runs. The extension also by default cleans up (i.e. deletes) any test databases
+ * older than 10 minutes when it runs.
+ * <p>
+ * You must supply a {@link org.kiwiproject.test.mongo.MongoTestProperties} instance which tells the extension which
+ * Mongo database to use by registering the extension (see below).
+ * <p>
+ * You can control when the database is dropped using the {@link DropTime} argument. You can control whether collections
+ * are dropped after each test or whether only the collection records are deleted using {@link CleanupOption}. You can
+ * also tell the extension to skip cleanup of old test databases. You can instantiate this extension using one of the
+ * constructors or using the provided builder.
+ * <p>
+ * For example using a constructor:
+ * <pre>
+ * private static final MongoTestProperties MONGO_TEST_PROPERTIES = createMongoTestProperties();
+ *
+ * {@literal @}RegisterExtension
+ *  final MongoDbExtension mongoDbExtension = new MongoDbExtension(MONGO_TEST_PROPERTIES);
+ * </pre>
+ * Or using a builder:
+ * <pre>
+ * private static final MongoTestProperties MONGO_TEST_PROPERTIES = createMongoTestProperties();
+ *
+ * {@literal @}RegisterExtension
+ *  final MongoDbExtension mongoDbExtension = MongoDbExtension.builder()
+ *     .props(MONGO TEST PROPERTIES)
+ *     .dropTime(DropTime.BEFORE)
+ *     .skipCleanup(true)
+ *     .build();
+ * </pre>
+ */
+@Slf4j
+public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+    // TODO Docs on public and overridden methods and constructors...
+
+    // TODO Add top-level documentation saying that this extension needs to be registered at the class level (i.e. static)
+
+    private static final long CLEANUP_TIME_PERIOD_AMOUNT = 10L;
+    private static final ChronoUnit CLEANUP_TIME_PERIOD_UNIT = ChronoUnit.MINUTES;
+    private static final String SYSTEM_INDEXES_COLLECTION_NAME = "system.indexes";
+
+    @Getter
+    private final DropTime dropTime;
+
+    @Getter
+    private final CleanupOption cleanupOption;
+
+    @Getter
+    private final boolean skipCleanup;
+
+    @Getter
+    private final MongoTestProperties props;
+
+    @Getter
+    private final MongoClient mongo;
+
+    @Getter
+    private final String mongoUri;
+
+    @Getter
+    private final String databaseName;
+
+    /**
+     * When to drop the test databases. The extension default is {@link #AFTER_ALL}, which means the database is only
+     * dropped after all tests have run.
+     */
+    public enum DropTime {
+        BEFORE_EACH, AFTER_EACH, AFTER_ALL
+    }
+
+    /**
+     * How to handle records after each individual test. The extension default is {@link #REMOVE_RECORDS}, which will
+     * delete the records in existing collections in the test database, but not delete the collections themselves.
+     */
+    public enum CleanupOption {
+        REMOVE_RECORDS, REMOVE_COLLECTION
+    }
+
+    public MongoDbExtension(MongoTestProperties props) {
+        this(props, DropTime.AFTER_ALL);
+    }
+
+    public MongoDbExtension(MongoTestProperties props, DropTime dropTime) {
+        this(props, dropTime, CleanupOption.REMOVE_RECORDS, false);
+    }
+
+    public MongoDbExtension(MongoTestProperties props, DropTime dropTime, CleanupOption cleanupOption) {
+        this(props, dropTime, cleanupOption, false);
+    }
+
+    @Builder
+    private MongoDbExtension(MongoTestProperties props,
+                             DropTime dropTime,
+                             CleanupOption cleanupOption,
+                             boolean skipCleanup) {
+        this.dropTime = isNull(dropTime) ? DropTime.AFTER_ALL : dropTime;
+        this.cleanupOption = isNull(cleanupOption) ? CleanupOption.REMOVE_RECORDS : cleanupOption;
+        this.skipCleanup = skipCleanup;
+        this.props = props;
+        this.mongo = props.newMongoClient();
+        this.databaseName = props.getDatabaseName();
+        this.mongoUri = props.getUri();
+        cleanupDatabasesFromPriorTestRunsIfNecessary();
+    }
+
+    private void cleanupDatabasesFromPriorTestRunsIfNecessary() {
+        if (skipCleanup) {
+            LOG.warn("Skipping cleanup of previous test databases");
+            return;
+        }
+
+        LOG.debug("Clean up databases from prior test runs that are older than {} {}",
+                CLEANUP_TIME_PERIOD_AMOUNT, CLEANUP_TIME_PERIOD_UNIT);
+
+        var keepThresholdMillis = Instant.now().minus(CLEANUP_TIME_PERIOD_AMOUNT, CLEANUP_TIME_PERIOD_UNIT).toEpochMilli();
+        var databasesToDrop = newArrayList(mongo.listDatabaseNames().iterator())
+                .stream()
+                .filter(name -> isUnitTestDatabaseForThisService(name, props))
+                .filter(name -> databaseIsOlderThanThreshold(name, keepThresholdMillis))
+                .collect(toList());
+
+        LOG.info("Removing {} databases from prior test runs: {}", databasesToDrop.size(), databasesToDrop);
+        databasesToDrop.forEach(this::cleanThenDropDatabase);
+    }
+
+    @VisibleForTesting
+    static boolean isUnitTestDatabaseForThisService(String name, MongoTestProperties props) {
+        return name.startsWith(f("{}{}", props.getServiceName(), UNIT_TEST_ID))
+                || name.startsWith(f("{}{}", props.getServiceName(), UNIT_TEST_ID_SHORT));
+    }
+
+    @VisibleForTesting
+    static boolean databaseIsOlderThanThreshold(String name, long keepThresholdMillis) {
+        var lastUnderscoreIndex = name.lastIndexOf('_');
+        var databaseCreatedAtMillis = Long.parseLong(name.substring(lastUnderscoreIndex + 1));
+        return databaseCreatedAtMillis <= keepThresholdMillis;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        if (dropTime == DropTime.BEFORE_EACH) {
+            dropDatabase();
+            LOG.debug("@BeforeEach: Database {} was dropped", databaseName);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        if (dropTime == DropTime.AFTER_ALL) {
+            clearCollections(databaseName, cleanupOption);
+            LOG.debug("@AfterEach: Collections cleaned with option {} in database {} @AfterEach", cleanupOption, databaseName);
+        } else if (dropTime == DropTime.AFTER_EACH) {
+            dropDatabase();
+            LOG.debug("@AfterEach: Database {} was dropped", databaseName);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        if (dropTime == DropTime.AFTER_ALL) {
+            dropDatabase();
+            LOG.debug("@AfterAll: Database {} was dropped", databaseName);
+        }
+    }
+
+    private void dropDatabase() {
+        LOG.debug("Drop database: {} (dropTime: {})", databaseName, dropTime);
+        cleanThenDropDatabase(databaseName);
+    }
+
+    private void cleanThenDropDatabase(String databaseName) {
+        LOG.debug("Clearing all collections, then dropping database: {}", databaseName);
+        clearCollections(databaseName, CleanupOption.REMOVE_COLLECTION);
+        dropDb(databaseName);
+    }
+
+    private void clearCollections(String databaseName, CleanupOption option) {
+        LOG.debug("Clearing all collections for database: {}", databaseName);
+        var mongoDatabase = mongo.getDatabase(databaseName);
+
+        // truncate collections (to avoid re-creating indexes)
+        mongoDatabase.listCollectionNames()
+                .forEach((Consumer<String>) collection -> {
+                    LOG.debug("Cleaning up collection {}.{} -- using cleanup option: {}",
+                            mongoDatabase.getName(), collection, option);
+
+                    if (option == CleanupOption.REMOVE_COLLECTION) {
+                        LOG.debug("Drop collection {}.{}", mongoDatabase.getName(), collection);
+                        mongoDatabase.getCollection(collection).drop();
+                    } else {
+                        clearCollectionRecords(mongoDatabase, collection);
+                    }
+                });
+        LOG.debug("Done clearing collections for database: {}", databaseName);
+    }
+
+    private void clearCollectionRecords(MongoDatabase db, String collection) {
+        if (!SYSTEM_INDEXES_COLLECTION_NAME.equals(collection)) {
+            LOG.debug("Delete records in {}.{}", db.getName(), collection);
+            db.getCollection(collection).deleteMany(new Document());
+        }
+    }
+
+    private void dropDb(String databaseName) {
+        LOG.debug("Dropping database: {}", databaseName);
+        var db = mongo.getDatabase(databaseName);
+        db.drop();
+    }
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
@@ -40,14 +40,14 @@ import java.util.function.Consumer;
  * <p>
  * For example using a constructor:
  * <pre>
- * private static final MongoTestProperties MONGO_TEST_PROPERTIES = createMongoTestProperties();
+ *  private static final MongoTestProperties MONGO_TEST_PROPERTIES = createMongoTestProperties();
  *
  * {@literal @}RegisterExtension
  *  static final MongoDbExtension mongoDbExtension = new MongoDbExtension(MONGO_TEST_PROPERTIES);
  * </pre>
  * Or using a builder:
  * <pre>
- * private static final MongoTestProperties MONGO_TEST_PROPERTIES = createMongoTestProperties();
+ *  private static final MongoTestProperties MONGO_TEST_PROPERTIES = createMongoTestProperties();
  *
  * {@literal @}RegisterExtension
  *  static final MongoDbExtension mongoDbExtension = MongoDbExtension.builder()

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
@@ -36,8 +36,9 @@ import java.util.function.Consumer;
  * <p>
  * You can control when the database is dropped using the {@link DropTime} argument. You can control whether collections
  * are dropped after each test or whether only the collection records are deleted using {@link CleanupOption}. You can
- * also tell the extension to skip cleanup of old test databases. You can instantiate this extension using one of the
- * constructors or using the provided builder.
+ * also tell the extension to skip cleanup of old test databases using the {@code skipDatabaseCleanup} (only available
+ * via the builder). Finally, you can instantiate this extension using one of the constructors or using the provided
+ * builder.
  * <p>
  * Note also that if using an in-memory Mongo server (e.g.
  * <a href="https://mvnrepository.com/artifact/de.bwaldvogel/mongo-java-server">mongo-java-server</a>), then the
@@ -61,7 +62,7 @@ import java.util.function.Consumer;
  *  static final MongoDbExtension mongoDbExtension = MongoDbExtension.builder()
  *     .props(MONGO TEST PROPERTIES)
  *     .dropTime(DropTime.BEFORE)
- *     .skipCleanup(true)
+ *     .skipDatabaseCleanup(true)
  *     .build();
  * </pre>
  */
@@ -79,7 +80,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
     private final CleanupOption cleanupOption;
 
     @Getter
-    private final boolean skipCleanup;
+    private final boolean skipDatabaseCleanup;
 
     @Getter
     private final MongoTestProperties props;
@@ -123,7 +124,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
      * Create a new extension with the given {@link MongoTestProperties}. The default drop and cleanup options are
      * used. Cleanup of collections is never skipped.
      * <p>
-     * Alternatively, use the fluent builder, which also permits changing the {@code skipCleanup} option.
+     * Alternatively, use the fluent builder, which also permits changing the {@code skipDatabaseCleanup} option.
      *
      * @param props the Mongo properties to use
      */
@@ -135,7 +136,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
      * Create a new extension with the given {@link MongoTestProperties} and {@link DropTime}. The default cleanup
      * option is used. Cleanup of collections is never skipped.
      * <p>
-     * Alternatively, use the fluent builder, which also permits changing the {@code skipCleanup} option.
+     * Alternatively, use the fluent builder, which also permits changing the {@code skipDatabaseCleanup} option.
      *
      * @param props    the Mongo properties to use
      * @param dropTime when should the test database be dropped?
@@ -148,7 +149,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
      * Create a new extension with the given {@link MongoTestProperties}, {@link DropTime}, and {@link CleanupOption}.
      * Cleanup of collections is never skipped.
      * <p>
-     * Alternatively, use the fluent builder, which also permits changing the {@code skipCleanup} option.
+     * Alternatively, use the fluent builder, which also permits changing the {@code skipDatabaseCleanup} option.
      *
      * @param props         the Mongo properties to use
      * @param dropTime      when should the test database be dropped?
@@ -162,10 +163,10 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
     private MongoDbExtension(MongoTestProperties props,
                              DropTime dropTime,
                              CleanupOption cleanupOption,
-                             boolean skipCleanup) {
+                             boolean skipDatabaseCleanup) {
         this.dropTime = isNull(dropTime) ? DropTime.AFTER_ALL : dropTime;
         this.cleanupOption = isNull(cleanupOption) ? CleanupOption.REMOVE_RECORDS : cleanupOption;
-        this.skipCleanup = skipCleanup;
+        this.skipDatabaseCleanup = skipDatabaseCleanup;
         this.props = requireNotNull(props);
         this.mongo = props.newMongoClient();
         this.databaseName = props.getDatabaseName();
@@ -174,7 +175,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
     }
 
     private void cleanupDatabasesFromPriorTestRunsIfNecessary() {
-        if (skipCleanup) {
+        if (skipDatabaseCleanup) {
             LOG.warn("Skipping cleanup of previous test databases");
             return;
         }

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -110,10 +110,9 @@ public class MongoTestProperties {
         this.hostName = hostName;
         this.port = port;
         this.serviceName = serviceName;
-        var nonNullServiceHostBehavior =
-                isNull(serviceHostDomain) ? ServiceHostDomain.STRIP : serviceHostDomain;
-        this.serviceHostDomain = nonNullServiceHostBehavior;
-        var normalizedServiceHost = serviceHost(serviceHost, nonNullServiceHostBehavior);
+        var nonNullServiceHostDomain = isNull(serviceHostDomain) ? ServiceHostDomain.STRIP : serviceHostDomain;
+        this.serviceHostDomain = nonNullServiceHostDomain;
+        var normalizedServiceHost = serviceHost(serviceHost, nonNullServiceHostDomain);
         this.serviceHost = normalizedServiceHost;
         this.databaseName = unitTestDatabaseName(serviceName, normalizedServiceHost);
         this.uri = mongoUri(hostName, port, databaseName);

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -8,6 +8,7 @@ import static org.apache.commons.lang3.StringUtils.containsAny;
 import static org.apache.commons.lang3.StringUtils.replaceChars;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotBlank;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.base.KiwiStrings.splitOnCommas;
 
@@ -109,15 +110,24 @@ public class MongoTestProperties {
                                String serviceName,
                                String serviceHost,
                                @Nullable ServiceHostDomain serviceHostDomain) {
-        this.hostName = hostName;
-        this.port = port;
-        this.serviceName = serviceName;
+
+        this.hostName = requireNotBlank(hostName);
+        this.port = requireValidPort(port);
+        this.serviceName = requireNotBlank(serviceName);
+
         var nonNullServiceHostDomain = isNull(serviceHostDomain) ? ServiceHostDomain.STRIP : serviceHostDomain;
         this.serviceHostDomain = nonNullServiceHostDomain;
-        var normalizedServiceHost = serviceHost(serviceHost, nonNullServiceHostDomain);
+
+        var normalizedServiceHost = serviceHost(requireNotBlank(serviceHost), nonNullServiceHostDomain);
         this.serviceHost = normalizedServiceHost;
+
         this.databaseName = unitTestDatabaseName(serviceName, normalizedServiceHost);
         this.uri = mongoUri(hostName, port, databaseName);
+    }
+
+    private static int requireValidPort(int port) {
+        checkArgument(port >= 0 && port <= 65_535, "invalid port: must be in range [0, 65535]");
+        return port;
     }
 
     private static String serviceHost(String serviceHost, ServiceHostDomain serviceHostDomain) {

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -70,14 +70,14 @@ public class MongoTestProperties {
     int port;
     String serviceName;
     String serviceHost;
-    HostDomainBehavior serviceHostDomainBehavior;
+    ServiceHostDomain serviceHostDomain;
     String databaseName;
     String uri;
 
     /**
      * Should the domain be kept or stripped in service host names?
      */
-    public enum HostDomainBehavior {
+    public enum ServiceHostDomain {
         /**
          * Keep the domain name, e.g. {@code service1.acme.com} stays as-is.
          */
@@ -94,36 +94,35 @@ public class MongoTestProperties {
      * <p>
      * Use the fluent builder as an alternative to this constructor.
      *
-     * @param hostName                  the host where MongoDB is located
-     * @param port                      the port that MongoDB is listening on
-     * @param serviceName               the name of the service/application being tested
-     * @param serviceHost               the host of the service/application being tested
-     * @param serviceHostDomainBehavior how to handle domains in the given {@code serviceHost}
-     *                                  (defaults to {@link HostDomainBehavior#STRIP STRIP} if this
-     *                                  argument is {@code null})
+     * @param hostName          the host where MongoDB is located
+     * @param port              the port that MongoDB is listening on
+     * @param serviceName       the name of the service/application being tested
+     * @param serviceHost       the host of the service/application being tested
+     * @param serviceHostDomain how to handle domains in the given {@code serviceHost}
+     *                          (defaults to {@link ServiceHostDomain#STRIP STRIP} if this argument is {@code null})
      */
     @Builder
     public MongoTestProperties(String hostName,
                                int port,
                                String serviceName,
                                String serviceHost,
-                               @Nullable HostDomainBehavior serviceHostDomainBehavior) {
+                               @Nullable ServiceHostDomain serviceHostDomain) {
         this.hostName = hostName;
         this.port = port;
         this.serviceName = serviceName;
         var nonNullServiceHostBehavior =
-                isNull(serviceHostDomainBehavior) ? HostDomainBehavior.STRIP : serviceHostDomainBehavior;
-        this.serviceHostDomainBehavior = nonNullServiceHostBehavior;
+                isNull(serviceHostDomain) ? ServiceHostDomain.STRIP : serviceHostDomain;
+        this.serviceHostDomain = nonNullServiceHostBehavior;
         var normalizedServiceHost = serviceHost(serviceHost, nonNullServiceHostBehavior);
         this.serviceHost = normalizedServiceHost;
         this.databaseName = unitTestDatabaseName(serviceName, normalizedServiceHost);
         this.uri = mongoUri(hostName, port, databaseName);
     }
 
-    private static String serviceHost(String serviceHost, HostDomainBehavior hostDomainBehavior) {
-        checkArgumentNotNull(hostDomainBehavior);
+    private static String serviceHost(String serviceHost, ServiceHostDomain serviceHostDomain) {
+        checkArgumentNotNull(serviceHostDomain);
 
-        if (hostDomainBehavior == HostDomainBehavior.KEEP) {
+        if (serviceHostDomain == ServiceHostDomain.KEEP) {
             return serviceHost;
         }
 

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -28,8 +28,9 @@ import javax.annotation.Nullable;
  * current timestamp is also included in the generated test database names to provide additional uniqueness in addition
  * to the service/application name and host.
  * <p>
- * Intended to be used in conjunction with (TODO - add link reference to MongoDbExtension) though there is no reason it cannot be
- * used standalone to generate database names for test purposes as well as the MongoDB client URI.
+ * Intended to be used in conjunction with {@link org.kiwiproject.test.junit.jupiter.MongoDbExtension} though there is
+ * no reason it cannot be used standalone to generate database names for test purposes as well as the MongoDB
+ * client URI.
  * <p>
  * Per MongoDB <a href="https://docs.mongodb.com/manual/reference/limits/#naming-restrictions">Naming Restrictions</a>,
  * "Database names cannot be empty and must have fewer than 64 characters". Thus the maximum length of database names

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterAllTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterAllTest.java
@@ -1,0 +1,93 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomething;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomethingElse;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDataInCollections;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
+
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import de.bwaldvogel.mongo.MongoServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+import java.net.InetSocketAddress;
+
+@DisplayName("MongoDbExtension: Drop @AfterAll")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MongoDbExtensionDropAfterAllTest {
+
+    private static final MongoServer MONGO_SERVER = startInMemoryMongoServer();
+    private static final InetSocketAddress INET_SOCKET_ADDRESS = MONGO_SERVER.getLocalAddress();
+    private static final MongoTestProperties TEST_PROPERTIES = buildMongoTestProperties(INET_SOCKET_ADDRESS);
+
+    private static MongoClient client;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = new MongoClient(new ServerAddress(INET_SOCKET_ADDRESS));
+    }
+
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    static final MongoDbExtension MONGO_DB_EXTENSION = new MongoDbExtension(TEST_PROPERTIES);
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        if (testInfo.getTags().contains("firstTest")) {
+            assertNoTestDatabaseExists(client);
+        } else {
+            assertTestDatabaseExists(client, TEST_PROPERTIES);
+        }
+
+        // Any data in collections should have been cleaned up by @AfterEach
+        assertNoDataInCollections(client, TEST_PROPERTIES);
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        // we should still see the database, since our @AfterAll runs before the extension's
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+    }
+
+    @Test
+    @Order(1)
+    @Tag("firstTest")
+    void shouldListCollections() {
+        var mongoDatabase = client.getDatabase(TEST_PROPERTIES.getDatabaseName());
+        assertThat(newArrayList(mongoDatabase.listCollectionNames().iterator())).isEmpty();
+    }
+
+    @Test
+    @Order(2)
+    void shouldInsertSomething() {
+        assertInsertSomething(client, TEST_PROPERTIES);
+    }
+
+    @Test
+    @Order(3)
+    void shouldInsertSomethingElse() {
+        assertInsertSomethingElse(client, TEST_PROPERTIES);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterAllTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterAllTest.java
@@ -2,9 +2,9 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomething;
-import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomethingElse;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDataInCollections;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertFirstDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertSecondDocument;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
@@ -82,12 +82,12 @@ class MongoDbExtensionDropAfterAllTest {
     @Test
     @Order(2)
     void shouldInsertSomething() {
-        assertInsertSomething(client, TEST_PROPERTIES);
+        assertNoDocumentsAndInsertFirstDocument(client, TEST_PROPERTIES);
     }
 
     @Test
     @Order(3)
     void shouldInsertSomethingElse() {
-        assertInsertSomethingElse(client, TEST_PROPERTIES);
+        assertNoDocumentsAndInsertSecondDocument(client, TEST_PROPERTIES);
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterEachTest.java
@@ -46,7 +46,7 @@ class MongoDbExtensionDropAfterEachTest {
     static final MongoDbExtension MONGO_DB_EXTENSION = MongoDbExtension.builder()
             .props(TEST_PROPERTIES)
             .dropTime(MongoDbExtension.DropTime.AFTER_EACH)
-            .skipCleanup(true)
+            .skipDatabaseCleanup(true)
             .build();
 
     @BeforeEach

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterEachTest.java
@@ -2,8 +2,8 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomething;
-import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomethingElse;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertFirstDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertSecondDocument;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
@@ -77,12 +77,12 @@ class MongoDbExtensionDropAfterEachTest {
     @Test
     @Order(2)
     void shouldInsertSomething() {
-        assertInsertSomething(client, TEST_PROPERTIES);
+        assertNoDocumentsAndInsertFirstDocument(client, TEST_PROPERTIES);
     }
 
     @Test
     @Order(3)
     void shouldInsertSomethingElse() {
-        assertInsertSomethingElse(client, TEST_PROPERTIES);
+        assertNoDocumentsAndInsertSecondDocument(client, TEST_PROPERTIES);
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropAfterEachTest.java
@@ -1,0 +1,88 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomething;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomethingElse;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
+
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import de.bwaldvogel.mongo.MongoServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+import java.net.InetSocketAddress;
+
+@DisplayName("MongoDbExtension: Drop Database @AfterEach")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MongoDbExtensionDropAfterEachTest {
+
+    private static final MongoServer MONGO_SERVER = startInMemoryMongoServer();
+    private static final InetSocketAddress INET_SOCKET_ADDRESS = MONGO_SERVER.getLocalAddress();
+    private static final MongoTestProperties TEST_PROPERTIES = buildMongoTestProperties(INET_SOCKET_ADDRESS);
+
+    private static MongoClient client;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = new MongoClient(new ServerAddress(INET_SOCKET_ADDRESS));
+    }
+
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    static final MongoDbExtension MONGO_DB_EXTENSION = MongoDbExtension.builder()
+            .props(TEST_PROPERTIES)
+            .dropTime(MongoDbExtension.DropTime.AFTER_EACH)
+            .skipCleanup(true)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        // we are deleting the database @AfterEach, so we should *never* see the test database here
+        assertNoTestDatabaseExists(client);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // this runs before the extension's @AfterEach, so we *should* see the databases after each test here
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        // we are dropping *after each* test, so we should *not* see the database after all tests
+        assertNoTestDatabaseExists(client);
+    }
+
+    @Test
+    @Order(1)
+    void shouldListCollections() {
+        var mongoDatabase = client.getDatabase(TEST_PROPERTIES.getDatabaseName());
+        assertThat(newArrayList(mongoDatabase.listCollectionNames().iterator())).isEmpty();
+    }
+
+    @Test
+    @Order(2)
+    void shouldInsertSomething() {
+        assertInsertSomething(client, TEST_PROPERTIES);
+    }
+
+    @Test
+    @Order(3)
+    void shouldInsertSomethingElse() {
+        assertInsertSomethingElse(client, TEST_PROPERTIES);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropBeforeEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropBeforeEachTest.java
@@ -2,8 +2,8 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomething;
-import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomethingElse;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertFirstDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertSecondDocument;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
@@ -77,12 +77,12 @@ class MongoDbExtensionDropBeforeEachTest {
     @Test
     @Order(2)
     void shouldInsertSomething() {
-        assertInsertSomething(client, TEST_PROPERTIES);
+        assertNoDocumentsAndInsertFirstDocument(client, TEST_PROPERTIES);
     }
 
     @Test
     @Order(3)
     void shouldInsertSomethingElse() {
-        assertInsertSomethingElse(client, TEST_PROPERTIES);
+        assertNoDocumentsAndInsertSecondDocument(client, TEST_PROPERTIES);
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropBeforeEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropBeforeEachTest.java
@@ -1,0 +1,88 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomething;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertInsertSomethingElse;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
+
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import de.bwaldvogel.mongo.MongoServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+import java.net.InetSocketAddress;
+
+@DisplayName("MongoDbExtension: Drop Database @BeforeEach")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MongoDbExtensionDropBeforeEachTest {
+
+    private static final MongoServer MONGO_SERVER = startInMemoryMongoServer();
+    private static final InetSocketAddress INET_SOCKET_ADDRESS = MONGO_SERVER.getLocalAddress();
+    private static final MongoTestProperties TEST_PROPERTIES = buildMongoTestProperties(INET_SOCKET_ADDRESS);
+
+    private static MongoClient client;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = new MongoClient(new ServerAddress(INET_SOCKET_ADDRESS));
+    }
+
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    static final MongoDbExtension MONGO_DB_EXTENSION = MongoDbExtension.builder()
+            .props(TEST_PROPERTIES)
+            .dropTime(MongoDbExtension.DropTime.BEFORE_EACH)
+            .skipCleanup(true)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        // the extension's @BeforeEach runs before ours, so we should *never* see the test database here
+        assertNoTestDatabaseExists(client);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // we are dropping *before* tests, so we *should* see the databases after each test
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        // we are dropping *before* tests, so we *should* see the database after all tests
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+    }
+
+    @Test
+    @Order(1)
+    void shouldListCollections() {
+        var mongoDatabase = client.getDatabase(TEST_PROPERTIES.getDatabaseName());
+        assertThat(newArrayList(mongoDatabase.listCollectionNames().iterator())).isEmpty();
+    }
+
+    @Test
+    @Order(2)
+    void shouldInsertSomething() {
+        assertInsertSomething(client, TEST_PROPERTIES);
+    }
+
+    @Test
+    @Order(3)
+    void shouldInsertSomethingElse() {
+        assertInsertSomethingElse(client, TEST_PROPERTIES);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropBeforeEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionDropBeforeEachTest.java
@@ -46,7 +46,7 @@ class MongoDbExtensionDropBeforeEachTest {
     static final MongoDbExtension MONGO_DB_EXTENSION = MongoDbExtension.builder()
             .props(TEST_PROPERTIES)
             .dropTime(MongoDbExtension.DropTime.BEFORE_EACH)
-            .skipCleanup(true)
+            .skipDatabaseCleanup(true)
             .build();
 
     @BeforeEach

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionNeverCleanupTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionNeverCleanupTest.java
@@ -63,7 +63,7 @@ class MongoDbExtensionNeverCleanupTest {
             .props(TEST_PROPERTIES)
             .dropTime(MongoDbExtension.DropTime.AFTER_ALL)  // ensure collection cleanup method is called in @AfterEach
             .cleanupOption(MongoDbExtension.CleanupOption.REMOVE_NEVER)
-            .skipCleanup(true)
+            .skipDatabaseCleanup(true)
             .build();
 
     @BeforeEach

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionNeverCleanupTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionNeverCleanupTest.java
@@ -1,0 +1,165 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoDocumentsAndInsertFirstDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertNoTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.assertTestDatabaseExists;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.docToInsertFirst;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.docToInsertSecond;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.findAllDocuments;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.findFirstDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.findSecondDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.getMongoDatabase;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.getTestCollection;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.insertSecondDocument;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
+
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import de.bwaldvogel.mongo.MongoServer;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+import java.net.InetSocketAddress;
+
+@DisplayName("MongoDbExtension: Never Cleanup Collections")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MongoDbExtensionNeverCleanupTest {
+
+    private static final MongoServer MONGO_SERVER = startInMemoryMongoServer();
+    private static final InetSocketAddress INET_SOCKET_ADDRESS = MONGO_SERVER.getLocalAddress();
+    private static final MongoTestProperties TEST_PROPERTIES = buildMongoTestProperties(INET_SOCKET_ADDRESS);
+
+    private static MongoClient client;
+
+    private MongoDatabase mongoDatabase;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = new MongoClient(new ServerAddress(INET_SOCKET_ADDRESS));
+    }
+
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    static final MongoDbExtension MONGO_DB_EXTENSION = MongoDbExtension.builder()
+            .props(TEST_PROPERTIES)
+            .dropTime(MongoDbExtension.DropTime.AFTER_ALL)  // ensure collection cleanup method is called in @AfterEach
+            .cleanupOption(MongoDbExtension.CleanupOption.REMOVE_NEVER)
+            .skipCleanup(true)
+            .build();
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        if (testInfo.getTags().contains("firstTest")) {
+            assertNoTestDatabaseExists(client);
+        } else {
+            assertTestDatabaseExists(client, TEST_PROPERTIES);
+            mongoDatabase = getMongoDatabase(client, TEST_PROPERTIES);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        // we should still see the database, since our @AfterAll runs before the extension's
+        assertTestDatabaseExists(client, TEST_PROPERTIES);
+
+        // we should still see the second document
+        var mongoDatabase = getMongoDatabase(client, TEST_PROPERTIES);
+        var collection = getTestCollection(mongoDatabase);
+        var documents = findAllDocuments(collection);
+        assertThat(documents).hasSize(1);
+    }
+
+    @Test
+    @Order(1)
+    @Tag("firstTest")
+    void shouldListCollections() {
+        var mongoDatabase = client.getDatabase(TEST_PROPERTIES.getDatabaseName());
+        assertThat(newArrayList(mongoDatabase.listCollectionNames().iterator())).isEmpty();
+    }
+
+    @Test
+    @Order(2)
+    void shouldInsertSomething() {
+        assertNoDocumentsAndInsertFirstDocument(client, TEST_PROPERTIES);
+    }
+
+    @Test
+    @Order(3)
+    void shouldSeeDocumentsFromPreviousTestAndInsertSomethingElse() {
+        var collection = getTestCollection(mongoDatabase);
+        var documents = findAllDocuments(collection);
+        assertThat(documents).hasSize(1);
+
+        var document = first(documents);
+        assertContainsAllExpectedProperties(document, docToInsertFirst());
+
+        insertSecondDocument(collection);
+    }
+
+    @Test
+    @Order(4)
+    void shouldSeeDocumentsFromPreviousTests() {
+        var collection = getTestCollection(mongoDatabase);
+        var documents = findAllDocuments(collection);
+        assertThat(documents).hasSize(2);
+
+        var firstDoc = findFirstDocument(documents);
+        assertContainsAllExpectedProperties(firstDoc, docToInsertFirst());
+
+        var secondDoc = findSecondDocument(documents);
+        assertContainsAllExpectedProperties(secondDoc, docToInsertSecond());
+    }
+
+    @Test
+    @Order(5)
+    void shouldSeeDocumentsFromPreviousTestsAndDeleteOneDocument() {
+        var collection = getTestCollection(mongoDatabase);
+        var documents = findAllDocuments(collection);
+        assertThat(documents).hasSize(2);
+
+        var deleteResult = collection.deleteOne(Filters.eq("foo", "bar"));
+        assertThat(deleteResult.getDeletedCount())
+                .describedAs("The first document should have been deleted")
+                .isOne();
+    }
+
+    @Test
+    @Order(6)
+    void shouldSeeRemainingDocumentsFromPreviousTests() {
+        var collection = getTestCollection(mongoDatabase);
+        var documents = findAllDocuments(collection);
+        assertThat(documents).hasSize(1);
+
+        assertThatCode(() -> findSecondDocument(documents))
+                .describedAs("The second document should still exist but was not found")
+                .doesNotThrowAnyException();
+    }
+
+    private void assertContainsAllExpectedProperties(Document actualDoc, Document expectedDoc) {
+        assertThat(actualDoc.entrySet()).containsAll(expectedDoc.entrySet());
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -1,0 +1,116 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
+import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
+
+import de.bwaldvogel.mongo.MongoServer;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+@DisplayName("MongoDbExtension: Construction")
+@ExtendWith(SoftAssertionsExtension.class)
+class MongoDbExtensionTest {
+
+    private MongoServer mongoServer;
+    private MongoTestProperties testProperties;
+
+    @BeforeEach
+    void setUp() {
+        mongoServer = startInMemoryMongoServer();
+        testProperties = buildMongoTestProperties(mongoServer.getLocalAddress());
+    }
+
+    @AfterEach
+    void tearDown() {
+        mongoServer.shutdownNow();
+    }
+
+    @Test
+    void shouldSetExtensionProperties(SoftAssertions softly) {
+        var extension = new MongoDbExtension(testProperties);
+
+        softly.assertThat(extension.getProps()).isNotNull();
+        softly.assertThat(extension.getMongo()).isNotNull();
+        softly.assertThat(extension.getMongoUri()).isNotBlank();
+        softly.assertThat(extension.getDatabaseName()).isNotBlank();
+    }
+
+    @Nested
+    class IsUnitTestDatabaseForThisService {
+
+        // TODO...
+    }
+
+    @Nested
+    class DatabaseIsOlderThanThreshold {
+
+        // TODO...
+    }
+
+    @Nested
+    class Constructor {
+
+        @Test
+        void shouldCreateWithTestProperties(SoftAssertions softly) {
+            var extension = new MongoDbExtension(testProperties);
+
+            softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_ALL);
+            softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_RECORDS);
+            softly.assertThat(extension.isSkipCleanup()).isFalse();
+        }
+
+        @Test
+        void shouldCreateWithTestPropertiesAndDropTime(SoftAssertions softly) {
+            var extension = new MongoDbExtension(testProperties, MongoDbExtension.DropTime.AFTER_EACH);
+
+            softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_EACH);
+            softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_RECORDS);
+            softly.assertThat(extension.isSkipCleanup()).isFalse();
+        }
+
+        @Test
+        void shouldCreateWithTestPropertiesAndDropTimeAndCleanupOption(SoftAssertions softly) {
+            var extension = new MongoDbExtension(testProperties, MongoDbExtension.DropTime.AFTER_EACH, MongoDbExtension.CleanupOption.REMOVE_COLLECTION);
+
+            softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_EACH);
+            softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_COLLECTION);
+            softly.assertThat(extension.isSkipCleanup()).isFalse();
+        }
+    }
+
+    @Nested
+    class Builder {
+
+        @Test
+        void shouldCreateWithDefaults(SoftAssertions softly) {
+            var extension = MongoDbExtension.builder()
+                    .props(testProperties)
+                    .build();
+
+            softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_ALL);
+            softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_RECORDS);
+            softly.assertThat(extension.isSkipCleanup()).isFalse();
+        }
+
+        @Test
+        void shouldCreateWithExplicitOptions(SoftAssertions softly) {
+            var extension = MongoDbExtension.builder()
+                    .props(testProperties)
+                    .dropTime(MongoDbExtension.DropTime.BEFORE_EACH)
+                    .cleanupOption(MongoDbExtension.CleanupOption.REMOVE_COLLECTION)
+                    .skipCleanup(true)
+                    .build();
+
+            softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.BEFORE_EACH);
+            softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_COLLECTION);
+            softly.assertThat(extension.isSkipCleanup()).isTrue();
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.test.junit.jupiter;
 
+import static com.google.common.base.Verify.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
@@ -15,7 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.mongo.MongoTestProperties;
+import org.kiwiproject.test.mongo.MongoTestProperties.ServiceHostDomain;
 
 @DisplayName("MongoDbExtension: Construction")
 @ExtendWith(SoftAssertionsExtension.class)
@@ -48,7 +51,48 @@ class MongoDbExtensionTest {
     @Nested
     class IsUnitTestDatabaseForThisService {
 
-        // TODO...
+        @ParameterizedTest
+        @CsvSource({
+                "test-service, host1.acme.com, STRIP",
+                "test-service, host1.acme.com, KEEP",
+                "this-is-a-service, host1.acme.com, STRIP",
+                "this-is-a-service, host1.acme.com, KEEP",
+                "this-is-a-really-really-really-really-really-really-long-service, host1.acme.com, KEEP",
+                "1234567890123456789012345678901234567890123456, host1.acme.com, STRIP",
+                "1234567890123456789012345678901234567890123456, host1.acme.com, KEEP"
+        })
+        void shouldBeTrue_WhenDatabaseName_ContainsTestDatabaseNameWithoutTimestamp(
+                String serviceName,
+                String serviceHost,
+                ServiceHostDomain serviceHostDomain) {
+
+            var testProps = MongoTestProperties.builder()
+                    .hostName("localhost")
+                    .port(27_017)
+                    .serviceName(serviceName)
+                    .serviceHost(serviceHost)
+                    .serviceHostDomain(serviceHostDomain)
+                    .build();
+
+            assertThat(MongoDbExtension.isUnitTestDatabaseForThisService(testProps.getDatabaseName(), testProps))
+                    .isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "test-service_unit_test_host1",
+                "another-service_unit_test_localhost",
+                "yet-another-service_unit_test_localhost"
+        })
+        void shouldBeFalse_WhenDatabaseName_DoesNotContainTestDatabaseNameWithoutTimestamp(String databaseName) {
+            var testPropsDbName = testProperties.getDatabaseNameWithoutTimestamp();
+            verify(testPropsDbName.equals("test-service_unit_test_localhost"),
+                    "Expected testProperties database name (w/o timestamp) to be: test-service_unit_test_localhost but was: %s",
+                    testPropsDbName);
+
+            assertThat(MongoDbExtension.isUnitTestDatabaseForThisService(databaseName, testProperties))
+                    .isFalse();
+        }
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -61,7 +61,7 @@ class MongoDbExtensionTest {
 
             softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_ALL);
             softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_RECORDS);
-            softly.assertThat(extension.isSkipCleanup()).isFalse();
+            softly.assertThat(extension.isSkipDatabaseCleanup()).isFalse();
         }
 
         @Test
@@ -70,7 +70,7 @@ class MongoDbExtensionTest {
 
             softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_EACH);
             softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_RECORDS);
-            softly.assertThat(extension.isSkipCleanup()).isFalse();
+            softly.assertThat(extension.isSkipDatabaseCleanup()).isFalse();
         }
 
         @Test
@@ -79,7 +79,7 @@ class MongoDbExtensionTest {
 
             softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_EACH);
             softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_COLLECTION);
-            softly.assertThat(extension.isSkipCleanup()).isFalse();
+            softly.assertThat(extension.isSkipDatabaseCleanup()).isFalse();
         }
     }
 
@@ -94,7 +94,7 @@ class MongoDbExtensionTest {
 
             softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.AFTER_ALL);
             softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_RECORDS);
-            softly.assertThat(extension.isSkipCleanup()).isFalse();
+            softly.assertThat(extension.isSkipDatabaseCleanup()).isFalse();
         }
 
         @Test
@@ -103,12 +103,12 @@ class MongoDbExtensionTest {
                     .props(testProperties)
                     .dropTime(MongoDbExtension.DropTime.BEFORE_EACH)
                     .cleanupOption(MongoDbExtension.CleanupOption.REMOVE_COLLECTION)
-                    .skipCleanup(true)
+                    .skipDatabaseCleanup(true)
                     .build();
 
             softly.assertThat(extension.getDropTime()).isEqualTo(MongoDbExtension.DropTime.BEFORE_EACH);
             softly.assertThat(extension.getCleanupOption()).isEqualTo(MongoDbExtension.CleanupOption.REMOVE_COLLECTION);
-            softly.assertThat(extension.isSkipCleanup()).isTrue();
+            softly.assertThat(extension.isSkipDatabaseCleanup()).isTrue();
         }
     }
 
@@ -223,10 +223,10 @@ class MongoDbExtensionTest {
         }
 
         @Test
-        void shouldNotCleanupOldDatabases_WhenSkipCleanupOptionIsTrue() {
+        void shouldNotCleanupOldDatabases_WhenSkipDatabaseCleanupOptionIsTrue() {
             MongoDbExtension.builder()
                     .props(testProperties)
-                    .skipCleanup(true)
+                    .skipDatabaseCleanup(true)
                     .build();
 
             var databaseNames = MongoDbTestHelpers.databaseNames(mongoClient);

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.mongo.MongoTestProperties;
 import org.kiwiproject.test.mongo.MongoTestProperties.ServiceHostDomain;
 
-@DisplayName("MongoDbExtension: Construction")
+@DisplayName("MongoDbExtension")
 @ExtendWith(SoftAssertionsExtension.class)
 class MongoDbExtensionTest {
 

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.test.junit.jupiter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.buildMongoTestProperties;
 import static org.kiwiproject.test.junit.jupiter.MongoDbTestHelpers.startInMemoryMongoServer;
 
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.kiwiproject.test.mongo.MongoTestProperties;
 
 @DisplayName("MongoDbExtension: Construction")
@@ -51,7 +54,21 @@ class MongoDbExtensionTest {
     @Nested
     class DatabaseIsOlderThanThreshold {
 
-        // TODO...
+        @ParameterizedTest
+        @CsvSource({
+                "1602375491862, test-service_unit_test_host1_1602375491864, false",  // db created before threshold
+                "1602375491863, test-service_unit_test_host1_1602375491864, false",  // db created before threshold
+                "1602375491864, test-service_unit_test_host1_1602375491864, true",   // db created at threshold
+                "1602375491865, test-service_unit_test_host1_1602375491864, true",   // db created after threshold
+                "1602375491866, test-service_unit_test_host1_1602375491864, true",   // db created after threshold
+        })
+        void shouldCompareDatabaseTimestampToKeepThreshold(long keepThresholdMillis,
+                                                           String databaseName,
+                                                           boolean expectedOlderThan) {
+
+            assertThat(MongoDbExtension.databaseIsOlderThanThreshold(databaseName, keepThresholdMillis))
+                    .isEqualTo(expectedOlderThan);
+        }
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbTestHelpers.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbTestHelpers.java
@@ -1,0 +1,82 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
+import lombok.experimental.UtilityClass;
+import org.bson.Document;
+import org.kiwiproject.test.mongo.MongoTestProperties;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+@UtilityClass
+class MongoDbTestHelpers {
+
+    static MongoServer startInMemoryMongoServer() {
+        var mongoServer = new MongoServer(new MemoryBackend());
+        mongoServer.bind();
+        return mongoServer;
+    }
+
+    static MongoTestProperties buildMongoTestProperties(InetSocketAddress serverAddress) {
+        return MongoTestProperties.builder()
+                .hostName(serverAddress.getHostName())
+                .port(serverAddress.getPort())
+                .serviceName("test-service")
+                .serviceHost("localhost")
+                .build();
+    }
+
+    static void assertTestDatabaseExists(MongoClient client, MongoTestProperties testProperties) {
+        assertThat(databaseNames(client)).containsExactly(testProperties.getDatabaseName());
+    }
+
+    static void assertNoTestDatabaseExists(MongoClient client) {
+        assertThat(databaseNames(client)).isEmpty();
+    }
+
+    static void assertNoDataInCollections(MongoClient client, MongoTestProperties testProperties) {
+        var database = client.getDatabase(testProperties.getDatabaseName());
+        var collectionNameIterator = database
+                .listCollectionNames()
+                .iterator();
+
+        var collectionNames = newArrayList(collectionNameIterator);
+
+        collectionNames.stream()
+                .filter(collectionName -> !"system.indexes" .equals(collectionName))
+                .forEach(collection -> assertThat(database.getCollection(collection).countDocuments()).isZero());
+    }
+
+    static List<String> databaseNames(MongoClient client) {
+        return ImmutableList.copyOf(client.listDatabaseNames());
+    }
+
+    static void assertInsertSomething(MongoClient client, MongoTestProperties testProperties) {
+        var mongoDatabase = client.getDatabase(testProperties.getDatabaseName());
+        MongoCollection<Document> testCollection = mongoDatabase.getCollection("testcollection");
+        assertThat(testCollection.countDocuments()).isZero();
+
+        var doc = new Document().append("foo", "bar");
+        testCollection.insertOne(doc);
+        assertThat(testCollection.countDocuments()).isOne();
+        assertThat(databaseNames(client)).containsExactly(testProperties.getDatabaseName());
+    }
+
+    static void assertInsertSomethingElse(MongoClient client, MongoTestProperties testProperties) {
+        var mongoDatabase = client.getDatabase(testProperties.getDatabaseName());
+        MongoCollection<Document> testCollection = mongoDatabase.getCollection("testcollection");
+        assertThat(testCollection.countDocuments()).isZero();
+
+        var doc = new Document().append("ham", "eggs");
+        testCollection.insertOne(doc);
+        assertThat(testCollection.countDocuments()).isOne();
+        assertThat(databaseNames(client)).containsExactly(testProperties.getDatabaseName());
+    }
+}

--- a/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.kiwiproject.test.mongo.MongoTestProperties.HostDomainBehavior;
+import org.kiwiproject.test.mongo.MongoTestProperties.ServiceHostDomain;
 
 import java.util.regex.Pattern;
 
@@ -164,32 +164,32 @@ class MongoTestPropertiesTest {
         }
 
         @ParameterizedTest
-        @EnumSource(HostDomainBehavior.class)
-        void shouldUseConstructor(HostDomainBehavior hostDomainBehavior, SoftAssertions softly) {
-            var properties = new MongoTestProperties(hostName, port, serviceName, serviceHost, hostDomainBehavior);
+        @EnumSource(ServiceHostDomain.class)
+        void shouldUseConstructor(ServiceHostDomain serviceHostDomain, SoftAssertions softly) {
+            var properties = new MongoTestProperties(hostName, port, serviceName, serviceHost, serviceHostDomain);
 
-            assertProperties(softly, properties, hostDomainBehavior);
+            assertProperties(softly, properties, serviceHostDomain);
         }
 
         @ParameterizedTest
-        @EnumSource(HostDomainBehavior.class)
-        void shouldUseBuilder(HostDomainBehavior hostDomainBehavior, SoftAssertions softly) {
+        @EnumSource(ServiceHostDomain.class)
+        void shouldUseBuilder(ServiceHostDomain serviceHostDomain, SoftAssertions softly) {
             var properties = MongoTestProperties.builder()
                     .hostName(hostName)
                     .port(port)
                     .serviceName(serviceName)
                     .serviceHost(serviceHost)
-                    .serviceHostDomainBehavior(hostDomainBehavior)
+                    .serviceHostDomain(serviceHostDomain)
                     .build();
 
-            assertProperties(softly, properties, hostDomainBehavior);
+            assertProperties(softly, properties, serviceHostDomain);
         }
 
         @Test
         void shouldDefaultToStrippingHostDomain_WhenUsingConstructor(SoftAssertions softly) {
             var properties = new MongoTestProperties(hostName, port, serviceName, serviceHost, null);
 
-            assertProperties(softly, properties, HostDomainBehavior.STRIP);
+            assertProperties(softly, properties, ServiceHostDomain.STRIP);
         }
 
         @Test
@@ -202,19 +202,19 @@ class MongoTestPropertiesTest {
                     .serviceHost(serviceHost)
                     .build();
 
-            assertProperties(softly, properties, HostDomainBehavior.STRIP);
+            assertProperties(softly, properties, ServiceHostDomain.STRIP);
         }
 
         private void assertProperties(SoftAssertions softly,
                                       MongoTestProperties properties,
-                                      HostDomainBehavior serviceHostDomainBehavior) {
+                                      ServiceHostDomain serviceHostDomain) {
 
             softly.assertThat(properties.getHostName()).isEqualTo(hostName);
             softly.assertThat(properties.getPort()).isEqualTo(port);
             softly.assertThat(properties.getServiceName()).isEqualTo(serviceName);
-            softly.assertThat(properties.getServiceHostDomainBehavior()).isEqualTo(serviceHostDomainBehavior);
+            softly.assertThat(properties.getServiceHostDomain()).isEqualTo(serviceHostDomain);
 
-            var keepDomain = serviceHostDomainBehavior == HostDomainBehavior.KEEP;
+            var keepDomain = serviceHostDomain == ServiceHostDomain.KEEP;
             var expectedServiceHost = keepDomain ? serviceHost : serviceHostMinusDomain;
             var expectedDbNamePrefix = keepDomain ?
                     "test-service_unit_test_service-host-1_acme_com_" : "test-service_unit_test_service-host-1_";
@@ -287,7 +287,7 @@ class MongoTestPropertiesTest {
         })
         void shouldStripLastUnderscoreAndTimestamp(String serviceName,
                                                    String serviceHost,
-                                                   HostDomainBehavior serviceHostDomainBehavior,
+                                                   ServiceHostDomain serviceHostDomain,
                                                    String expectedDatabaseNameWithoutTimestamp) {
 
             var testProperties = MongoTestProperties.builder()
@@ -295,7 +295,7 @@ class MongoTestPropertiesTest {
                     .port(27_017)
                     .serviceName(serviceName)
                     .serviceHost(serviceHost)
-                    .serviceHostDomainBehavior(serviceHostDomainBehavior)
+                    .serviceHostDomain(serviceHostDomain)
                     .build();
 
             assertThat(testProperties.getDatabaseNameWithoutTimestamp())
@@ -314,14 +314,14 @@ class MongoTestPropertiesTest {
         })
         void shouldExtractTimestamp(String serviceName,
                                     String serviceHost,
-                                    HostDomainBehavior serviceHostDomainBehavior) {
+                                    ServiceHostDomain serviceHostDomain) {
 
             var testProperties = MongoTestProperties.builder()
                     .hostName("localhost")
                     .port(27_017)
                     .serviceName(serviceName)
                     .serviceHost(serviceHost)
-                    .serviceHostDomainBehavior(serviceHostDomainBehavior)
+                    .serviceHostDomain(serviceHostDomain)
                     .build();
 
             // Yes, yes, the following basically does the same thing the getDatabaseTimestamp() method does,

--- a/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
@@ -167,6 +167,27 @@ class MongoTestPropertiesTest {
         }
 
         @ParameterizedTest
+        @CsvSource({
+                " , 8080, test-service , svc-host-1",
+                " '' , 8080, test-service , svc-host-1",
+                " mongo-host, -1, test-service, svc-host-1 ",
+                " mongo-host, 65536, test-service, svc-host-1 ",
+                " mongo-host, 8080,  , svc-host-1",
+                " mongo-host, 8080, '' , svc-host-1",
+                " mongo-host, 8080, test-service, ",
+                " mongo-host, 8080, test-service, '' ",
+        })
+        void shouldNotAllowNullsOrBlanks(String hostName, int port, String serviceName, String serviceHost) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> MongoTestProperties.builder()
+                            .hostName(hostName)
+                            .port(port)
+                            .serviceName(serviceName)
+                            .serviceHost(serviceHost)
+                            .build());
+        }
+
+        @ParameterizedTest
         @EnumSource(ServiceHostDomain.class)
         void shouldUseConstructor(ServiceHostDomain serviceHostDomain, SoftAssertions softly) {
             var properties = new MongoTestProperties(hostName, port, serviceName, serviceHost, serviceHostDomain);

--- a/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
@@ -194,7 +194,7 @@ class MongoTestPropertiesTest {
 
         @Test
         void shouldDefaultToStrippingHostDomain_WhenUsingBuilder(SoftAssertions softly) {
-            // hostDomainBehavior is not specified; it should use the default
+            // serviceHostDomain is not specified; it should use the default
             var properties = MongoTestProperties.builder()
                     .hostName(hostName)
                     .port(port)


### PR DESCRIPTION
* Add MongoDbExtension JUnit Jupiter extension
* Rename HostDomainBehavior enum in  MongoTestProperties
  to ServiceHostDomain to make more clear that it relates to
  the service host (and not the MongoDB host)
* Update/refactor MongoTestProperties constructor to properly pass
  the non-null serviceHostDomainBehavior to serviceHost, and also to
  pass the normalized service host to unitTestDatabaseName
* Add null arg check to MongoTestProperties#serviceHost
* Add instance method getDatabaseNameWithoutTimestamp() in
  MongoTestProperties which delegates to the static utility
  databaseNameWithoutTimestamp method
* Add instance method getDatabaseTimestamp() in MongoTestProperties
  which delegates to the static utility extractDatabaseTimestamp method
* Add test dependency for in-memory Mongo server for use by tests
* Update the docs in MongoTestProperties to reference MongoDbExtension
* Add multiple integration tests for MongoDbExtension which test the
  behavior when the test databases are dropped `@AfterAll` (default),
  `@BeforeEach`, and `@AfterEach`, as well as testing the `NEVER`
  collection cleanup option.
* Add unit test of MongoDbExtension that tests construction using the
  constructors and the Lombok builder, as well as cleanup of databases
  from previous test executions
* Add MongoDbTestHelpers as a helper class for the integration tests

Fixes #123