### PR TITLE
Update javadoc in H2FileBasedDatabaseExtension

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -39,13 +39,13 @@ import org.kiwiproject.test.h2.H2FileBasedDatabase;
  * class MySecondTest {
  *
  *    {@literal @}RegisterExtension
- *     static H2FileBasedDatabaseExtension databaseExtension = new H2FileBasedDatabaseExtension();
+ *     static final H2FileBasedDatabaseExtension DATABASE_EXTENSION = new H2FileBasedDatabaseExtension();
  *
  *    {@literal @}RegisterExtension
  *     final DaoExtension&lt;PersonDao&gt; jdbi3DaoExtension =
  *             DaoExtension.&lt;PersonDao&gt;builder()
  *                     .daoType(PersonDao.class)
- *                     .dataSource(databaseExtension.getDataSource())  // supply the DataSource here
+ *                     .dataSource(DATABASE_EXTENSION.getDataSource())  // supply the DataSource here
  *                     .plugin(new H2DatabasePlugin())
  *                     .build();
  * }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
@@ -16,22 +16,22 @@ import java.sql.SQLException;
 class H2FileBasedDatabaseExtensionRegisterTest {
 
     @RegisterExtension
-    static H2FileBasedDatabaseExtension databaseExtension = new H2FileBasedDatabaseExtension();
+    static final H2FileBasedDatabaseExtension DATABASE_EXTENSION = new H2FileBasedDatabaseExtension();
 
     @RegisterExtension
-    final H2DatabaseTestExtension testExtension = new H2DatabaseTestExtension(databaseExtension.getDatabase());
+    final H2DatabaseTestExtension testExtension = new H2DatabaseTestExtension(DATABASE_EXTENSION.getDatabase());
 
     @Test
     void shouldMakeDatabaseAvailableToTests() {
-        assertThat(databaseExtension.getDatabase()).isNotNull();
-        assertThat(databaseExtension.getUrl()).isNotBlank();
-        assertThat(databaseExtension.getDirectory()).isNotNull();
-        assertThat(databaseExtension.getDataSource()).isNotNull();
+        assertThat(DATABASE_EXTENSION.getDatabase()).isNotNull();
+        assertThat(DATABASE_EXTENSION.getUrl()).isNotBlank();
+        assertThat(DATABASE_EXTENSION.getDirectory()).isNotNull();
+        assertThat(DATABASE_EXTENSION.getDataSource()).isNotNull();
     }
 
     @Test
     void shouldSupplyDatabaseToTestExtension() {
-        assertThat(testExtension.getDatabase()).isSameAs(databaseExtension.getDatabase());
+        assertThat(testExtension.getDatabase()).isSameAs(DATABASE_EXTENSION.getDatabase());
     }
 
     @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})


### PR DESCRIPTION
* When used with @RegisterExtension, the static field can and should be
  final. Update docs to show this, and rename the variable in the
  example according to the UPPER_SNAKE_CASE convention.
* Change the H2FileBasedDatabaseExtensionRegisterTest to use
  UPPER_SNAKE_CASE for the static final field name.