### PR TITLE
Auto-install H2 and Postgres JDBI plugins in Jdbi3Helpers#buildJdbi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <javassist.version>3.27.0-GA</javassist.version>
         <jackson.version>2.10.5</jackson.version>
+        <jdbi3.version>3.14.4</jdbi3.version>
         <jersey-test-framework-core.version>2.31</jersey-test-framework-core.version>
         <jsonassert.version>1.5.0</jsonassert.version>
         <liquibase.version>3.8.9</liquibase.version>
@@ -56,7 +57,6 @@
         <error_prone_annotations.version>2.4.0</error_prone_annotations.version>
 
         <!-- Versions for test dependencies -->
-        <jdbi3.version>3.14.4</jdbi3.version>
         <mongo-java-server.version>1.36.0</mongo-java-server.version>
     </properties>
 
@@ -454,6 +454,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-postgres</artifactId>
+            <version>${jdbi3.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.jupiter.version}</version>
@@ -523,13 +530,6 @@
             <groupId>de.bwaldvogel</groupId>
             <artifactId>mongo-java-server</artifactId>
             <version>${mongo-java-server.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-postgres</artifactId>
-            <version>${jdbi3.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
* Change jdbi3-postgres dependency from test to provided scope and
  move dependency and version property accordingly in the pom
* Update Jdbi3Helpers#buildJdbi to automatically install the H2 or
  Postgres JDBI plugin if the database is detected as H2 or Postgres,
  respectively.
* Added several new helper utilities in Jdbi3Helpers:
  - DatabaseType enum
  - getPluginInstance
  - isPluginAvailable

Fixes #128