### PR TITLE
Fix several deprecation warnings

### DIFF
--- a/src/main/java/org/kiwiproject/test/assertj/jsonassert/JSONAssertSoftAssertions.java
+++ b/src/main/java/org/kiwiproject/test/assertj/jsonassert/JSONAssertSoftAssertions.java
@@ -32,6 +32,7 @@ public class JSONAssertSoftAssertions {
      *
      * @param softAssertions the soft assertions to use
      */
+    @SuppressWarnings("deprecation")  // we know that we are referencing a deprecated class in the docs
     public JSONAssertSoftAssertions(AbstractSoftAssertions softAssertions) {
         this.softAssertions = softAssertions;
     }

--- a/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
@@ -43,8 +43,10 @@ class JaxrsExceptionTestHelperTest {
 
             var jaxrsException = JaxrsExceptionTestHelper.toJaxrsException(response);
 
-            assertThat(jaxrsException).isEqualToComparingOnlyGivenFields(originalException,
-                    "statusCode", "message", "errors", "otherData");
+            assertThat(jaxrsException.getStatusCode()).isEqualTo(originalException.getStatusCode());
+            assertThat(jaxrsException.getErrors()).isEqualTo(originalException.getErrors());
+            assertThat(jaxrsException.getOtherData()).isEqualTo(originalException.getOtherData());
+            assertThat(jaxrsException.getRollUpStatus()).isEqualTo(originalException.getRollUpStatus());
         }
 
         @Test


### PR DESCRIPTION
* Suppress the warning in JSONAssertSoftAssertions, since we are
  intentionally referencing a deprecated class in the JavaDocs
* In JaxrsExceptionTestHelperTest, refactor call to the deprecated
  isEqualToComparingOnlyGivenFields with multiple assertions, since
  there no longer seems to be an equivalent of comparing only given
  fields. The AssertJ javadocs say: "Use the recursive comparison by
  calling usingRecursiveComparison() and specify the fields to ignore."
  This is not actually an equivalent feature; we want to specify the
  fields that should be compared, not the ones to ignore.