### PR TITLE
Update MongoDbExtension so it ignores non-test databases

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
@@ -21,6 +21,7 @@ import org.kiwiproject.test.mongo.MongoTestProperties;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -246,8 +247,13 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
 
     @VisibleForTesting
     static boolean isUnitTestDatabaseForThisService(String databaseName, MongoTestProperties props) {
-        return MongoTestProperties.databaseNameWithoutTimestamp(databaseName)
-                .equals(props.getDatabaseNameWithoutTimestamp());
+        if (MongoTestProperties.looksLikeTestDatabaseName(databaseName)) {
+            return Objects.equals(
+                    MongoTestProperties.databaseNameWithoutTimestamp(databaseName),
+                    props.getDatabaseNameWithoutTimestamp());
+        }
+
+        return false;
     }
 
     @VisibleForTesting

--- a/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
@@ -298,6 +298,38 @@ class MongoTestPropertiesTest {
     }
 
     @Nested
+    class LooksLikeTestDatabaseName {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "test-service_unit_test_localhost_1605412659693",
+                "test-service_unit_test_host1_1605412593043",
+                "this-is-a-service_unit_test_host1_acme_com_1605412633625",
+                "another_service___with_a_really_very_long_name_ut_1605412775385",
+        })
+        void shouldBeTrue_WhenIsUnitTestDatabaseName(String databaseName) {
+            assertThat(MongoTestProperties.looksLikeTestDatabaseName(databaseName)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "admin",
+                "local",
+                "test",
+                "customer_database",
+                "customer_unit_test_",
+                "customer_unit_test_notDigits",
+                "customer_ut_",
+                "customer_ut_notDigits",
+                "database_with_timestamp_1605412571082",
+                "_1605414136687"
+        })
+        void shouldBeFalse_WhenIsUnitTestDatabaseName(String databaseName) {
+            assertThat(MongoTestProperties.looksLikeTestDatabaseName(databaseName)).isFalse();
+        }
+    }
+
+    @Nested
     class GetDatabaseNameWithoutTimestamp {
 
         @ParameterizedTest


### PR DESCRIPTION
Update MongoDbExtension so that it ignores any databases that are not
unit test databases when performing prior database cleanup.

* Add MongoTestProperties#looksLikeTestDatabaseName method to perform
  basic checks on a given database name
* Modify MongoDbExtension#isUnitTestDatabaseForThisService to only
  perform the comparison with the MongoTestProperties database name
  if the MongoTestProperties#looksLikeTestDatabaseName method returns
  true; otherwise return false to ignore that database

Fixes #160