### PR TITLE
Fix Sonar projectKey property in the POM to be kiwi-test not kiwi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <mongo-java-server.version>1.36.0</mongo-java-server.version>
 
         <!-- Sonar properties -->
-        <sonar.projectKey>kiwiproject_kiwi</sonar.projectKey>
+        <sonar.projectKey>kiwiproject_kiwi-test</sonar.projectKey>
         <sonar.organization>kiwiproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>


### PR DESCRIPTION
This was causing incorrect results in Sonar, since it was sending as kiwi instead of kiwi-test