### PR TITLE
Mock the AdminEnvironment in DropwizardMockitoContext#mockEnvironment

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoContext.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoContext.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.AdminEnvironment;
 import io.dropwizard.setup.Environment;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,6 +24,7 @@ import javax.validation.Validator;
 @Builder(access = AccessLevel.PACKAGE)
 public class DropwizardMockitoContext {
     private final Environment environment;
+    private final AdminEnvironment adminEnvironment;
     private final JerseyEnvironment jersey;
     private final HealthCheckRegistry healthChecks;
     private final MetricRegistry metrics;

--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Verify;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.AdminEnvironment;
 import io.dropwizard.setup.Environment;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.test.validation.ValidationTestHelper;
@@ -53,6 +54,7 @@ public class DropwizardMockitoMocks {
         mockHealthCheckRegistry(env);
         mockMetricRegistry(env);
         mockLifecycleEnvironment(env);
+        mockAdminEnvironment(env);
         useObjectMapper(env, mapper);
         useValidator(env, validator);
         return env;
@@ -79,16 +81,17 @@ public class DropwizardMockitoMocks {
      * @return a context object providing easy access to the mocked Dropwizard application objects
      */
     public static DropwizardMockitoContext mockDropwizard(ObjectMapper mapper, Validator validator) {
-        var env = mock(Environment.class);
+        var env = mockEnvironment(mapper, validator);
         useObjectMapper(env, mapper);
         useValidator(env, validator);
 
         return DropwizardMockitoContext.builder()
                 .environment(env)
-                .jersey(mockJerseyEnvironment(env))
-                .healthChecks(mockHealthCheckRegistry(env))
-                .metrics(mockMetricRegistry(env))
-                .lifecycle(mockLifecycleEnvironment(env))
+                .adminEnvironment(env.admin())
+                .jersey(env.jersey())
+                .healthChecks(env.healthChecks())
+                .metrics(env.metrics())
+                .lifecycle(env.lifecycle())
                 .objectMapper(mapper)
                 .validator(validator)
                 .build();
@@ -144,6 +147,19 @@ public class DropwizardMockitoMocks {
         var lifecycleEnvironment = mock(LifecycleEnvironment.class);
         when(mockEnv.lifecycle()).thenReturn(lifecycleEnvironment);
         return lifecycleEnvironment;
+    }
+
+    /**
+     * Mock the {@link AdminEnvironment} in the given Dropwizard environment.
+     *
+     * @param mockEnv a mock {@link Environment}
+     * @return a mock {@link AdminEnvironment}
+     */
+    public static AdminEnvironment mockAdminEnvironment(Environment mockEnv) {
+        verifyIsMockitoMock(mockEnv);
+        var adminEnvironment = mock(AdminEnvironment.class);
+        when(mockEnv.admin()).thenReturn(adminEnvironment);
+        return adminEnvironment;
     }
 
     /**

--- a/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
@@ -60,6 +60,11 @@ class DropwizardMockitoMocksTest {
         }
 
         @Test
+        void shouldSetAdminEnvironment() {
+            assertIsMockitoMock(env.admin());
+        }
+
+        @Test
         void shouldSetObjectMapper() {
             assertThat(env.getObjectMapper()).isSameAs(OBJECT_MAPPER);
         }
@@ -114,6 +119,13 @@ class DropwizardMockitoMocksTest {
         }
 
         @Test
+        void shouldSetAdminEnvironment() {
+            var adminEnvironment = context.adminEnvironment();
+            assertIsMockitoMock(adminEnvironment);
+            assertThat(context.environment().admin()).isSameAs(adminEnvironment);
+        }
+
+        @Test
         void shouldSetObjectMapper() {
             var mapper = context.objectMapper();
             assertThat(mapper).isSameAs(OBJECT_MAPPER);
@@ -155,6 +167,7 @@ class DropwizardMockitoMocksTest {
                 assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockHealthCheckRegistry(realEnv));
                 assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockMetricRegistry(realEnv));
                 assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockLifecycleEnvironment(realEnv));
+                assertVerifyExceptionThrownBy(softly, () -> DropwizardMockitoMocks.mockAdminEnvironment(realEnv));
                 assertVerifyExceptionThrownBy(softly,
                         () -> DropwizardMockitoMocks.useObjectMapper(realEnv, OBJECT_MAPPER));
                 assertVerifyExceptionThrownBy(softly,
@@ -198,6 +211,13 @@ class DropwizardMockitoMocksTest {
         }
 
         @Test
+        void shouldMockAdminEnvironment() {
+            var adminEnv = DropwizardMockitoMocks.mockAdminEnvironment(env);
+            assertIsMockitoMock(adminEnv);
+            assertThat(env.admin()).isSameAs(adminEnv);
+        }
+
+        @Test
         void shouldUseObjectMapper() {
             var mapper = Jackson.newMinimalObjectMapper();
             DropwizardMockitoMocks.useObjectMapper(env, mapper);
@@ -217,7 +237,7 @@ class DropwizardMockitoMocksTest {
         assertThat(Mockito.mockingDetails(object).isMock()).isTrue();
     }
 
-    static class TestConfig extends Configuration {
+    private static class TestConfig extends Configuration {
     }
 
 }


### PR DESCRIPTION
* Add an AdminEnvironment to the DropwizardMockitoContext
* Add mockAdminEnvironment to DropwizardMockitoMocks
* Mock the AdminEnvironment in DropwizardMockitoMocks#mockEnvironment
* Update DropwizardMockitoMocks#mockDropwizard so it calls
  mockEnvironment and thereby gets the new mock AdminEnvironment

Closes #174