### PR TITLE
Re-enable tests that use embedded Postgres

### DIFF
--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
@@ -15,19 +15,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-/**
- * @implNote See the implementation note in {@link PostgresAppTestExtensionTest}.
- */
 @DisplayName("PostgresAppTestExtension: ConfigOverrides")
-@EnabledOnOs(OS.LINUX)
 class PostgresAppTestExtensionConfigOverridesTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -14,25 +14,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-/**
- * @implNote Due to several known issues in the zonkyio / embedded-postgres library on macOS Catalina,
- * we are enabling this only on Linux at present. See issues
- * <a href="https://github.com/zonkyio/embedded-postgres/issues/32">32</a>,
- * <a href="https://github.com/zonkyio/embedded-postgres/issues/40">40</a> for more details.
- * Also, issue <a href="https://github.com/zonkyio/embedded-postgres/issues/11">11</a> is related and
- * <a href="https://github.com/zonkyio/embedded-postgres/issues/11#issuecomment-533468269">this comment</a>
- * explains how to "fix" by exporting {@code LC_CTYPE} and {@code LC_ALL} environment variables if you want
- * to run this test on macOS.
- */
 @DisplayName("PostgresAppTestExtension")
-@EnabledOnOs(OS.LINUX)
 class PostgresAppTestExtensionTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/PostgresLiquibaseTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/PostgresLiquibaseTestExtensionTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.test.jdbi.Jdbi3GeneratedKeys;
 
@@ -26,7 +24,6 @@ import java.sql.SQLException;
 @DisplayName("PostgresLiquibaseTestExtension")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SuppressWarnings({"SqlNoDataSourceInspection", "SqlDialectInspection"})
-@EnabledOnOs(OS.LINUX)
 class PostgresLiquibaseTestExtensionTest {
 
     @RegisterExtension


### PR DESCRIPTION
Since we originally implemented these and had problems running the
tests on macOS, things seem to have gotten fixed. So this commit simply
removes the EnabledOnOs annotation that restricted to Linux. I don't
really care about Windows, and doubt anyone is using this there anyway.

See:

https://github.com/zonkyio/embedded-postgres/issues/32
https://github.com/zonkyio/embedded-postgres/issues/40

Also see:

https://github.com/zonkyio/embedded-postgres/issues/11
https://github.com/zonkyio/embedded-postgres/issues/11#issuecomment-533468269

for the original solution regarding the LC_CTYPE and LC_ALL environment
variables.

Closes #80
Closes #152