### PR TITLE
Add JUnit Jupiter ArgumentsSource to generate random double values

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
@@ -1,0 +1,54 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+
+/**
+ * An {@link ArgumentsProvider} that provides random integer values. Accepts a {@link RandomDoubleSource} to
+ * allow customization of the provided values.
+ *
+ * @see RandomDoubleSource
+ */
+class RandomDoubleArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<RandomDoubleSource> {
+
+    private RandomDoubleSource randomDoubleSource;
+
+    @Override
+    public void accept(RandomDoubleSource randomDoubleSource) {
+        this.randomDoubleSource = randomDoubleSource;
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        checkArgument(randomDoubleSource.min() <= randomDoubleSource.max(), "min must be equal or less than max");
+
+        var random = ThreadLocalRandom.current();
+        var originInclusive = randomDoubleSource.min();
+        var boundExclusive = calculateBound();
+        var count = randomDoubleSource.count();
+
+        return Stream.generate(() -> random.nextDouble(originInclusive, boundExclusive))
+                .map(Arguments::of)
+                .limit(count);
+    }
+
+    /**
+     * @implNote In order to get a random double up to and including the max, we have to pick an arbitrarily
+     * small number above the max so that {@link ThreadLocalRandom#nextDouble(double, double)} will at least
+     * come pretty close to the max, even if it never generates exactly the max.
+     */
+    private double calculateBound() {
+        if (randomDoubleSource.max() == Double.MAX_VALUE) {
+            return Double.MAX_VALUE;
+        }
+
+        return randomDoubleSource.max() + 1.0E-12;
+    }
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 /**
- * An {@link ArgumentsProvider} that provides random integer values. Accepts a {@link RandomDoubleSource} to
+ * An {@link ArgumentsProvider} that provides random double values. Accepts a {@link RandomDoubleSource} to
  * allow customization of the provided values.
  *
  * @see RandomDoubleSource

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleSource.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleSource.java
@@ -1,0 +1,52 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @RandomDoublesSource} is an {@link ArgumentsSource} that provides a limited number of random {@code double}
+ * values for use in parameterized tests.
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ArgumentsSource(RandomDoubleArgumentsProvider.class)
+public @interface RandomDoubleSource {
+
+    /**
+     * The minimum value this source will produce.
+     * <p>
+     * Defaults to {@link Double#MIN_VALUE}.
+     *
+     * @return the minimum value
+     */
+    double min() default Double.MIN_VALUE;
+
+    /**
+     * The maximum value this source will produce.
+     * <p>
+     * Defaults to {@link Double#MAX_VALUE}.
+     *
+     * @return the maximum value
+     * @implNote When set to {@link Double#MAX_VALUE}, the maximum is actually {@code (Double.MAX_VALUE - 1)} since
+     * {@link java.util.concurrent.ThreadLocalRandom#nextDouble(double, double)}  nextDouble} has an exclusive upper
+     * bound, and without resorting to using {@link java.math.BigDecimal} we can't ever get to {@link Double#MAX_VALUE}.
+     * We assume that if you really need the maximum value in a test, you can just write a test for that specific case.
+     */
+    double max() default Double.MAX_VALUE;
+
+    /**
+     * The number of random doubles to produce.
+     * <p>
+     * Defaults to 25.
+     *
+     * @return the number of doubles to produce
+     */
+    int count() default 25;
+
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
@@ -1,0 +1,119 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+@DisplayName("RandomDoubleArgumentsProvider")
+@Slf4j
+class RandomDoubleArgumentsProviderTest {
+
+    @Test
+    void shouldThrowIllegalArgumentException_WhenMaxLessThanMin() {
+        var randomDoubleSource = newRandomDoubleSource(10.0, 9.9, 25);
+        var provider = new RandomDoubleArgumentsProvider();
+        provider.accept(randomDoubleSource);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("min must be equal or less than max");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {10, 20, 42, 100, 500})
+    void shouldProduceTheExpectedNumberOfValues(int count) {
+        var min = ThreadLocalRandom.current().nextDouble(10.0);
+        var max = ThreadLocalRandom.current().nextDouble(20.0, 40.0);
+        var randomDoubleSource = newRandomDoubleSource(min, max, count);
+
+        var provider = new RandomDoubleArgumentsProvider();
+        provider.accept(randomDoubleSource);
+
+        var arguments = provider.provideArguments(null)
+                .map(Arguments::get)
+                .flatMap(Arrays::stream)
+                .mapToDouble(value -> (double) value)
+                .toArray();
+
+        assertThat(arguments).hasSize(count);
+    }
+
+    /**
+     * This test creates a provider that generates 1,000 doubles between a small range and repeats the test
+     * 10 times, in order to sanity check that we don't generate numbers outside the bounds with the
+     * small offset we add to the max.
+     */
+    @RepeatedTest(10)
+    void shouldProvideArgumentsWithinCustomBounds() {
+        var min = 30.0;
+        var max = 31.0;
+        var count = 1_000;
+        var randomDoubleSource = newRandomDoubleSource(min, max, count);
+
+        var provider = new RandomDoubleArgumentsProvider();
+        provider.accept(randomDoubleSource);
+
+        var arguments = provider.provideArguments(null)
+                .map(Arguments::get)
+                .flatMap(Arrays::stream)
+                .mapToDouble(value -> (double) value)
+                .toArray();
+
+        assertThat(arguments).hasSize(count);
+
+        var minGenerated = Arrays.stream(arguments).min().orElseThrow();
+        var maxGenerated = Arrays.stream(arguments).max().orElseThrow();
+        LOG.debug("minGenerated: {} , maxGenerated: {}", minGenerated, maxGenerated);
+
+        assertThat(minGenerated).isBetween(min, max);
+        assertThat(maxGenerated).isBetween(min, max);
+    }
+
+    @ParameterizedTest
+    @RandomDoubleSource
+    void shouldProvideRandomDoublesWithDefaultAnnotationValues(double value) {
+        assertThat(value).isBetween(Double.MIN_VALUE, Double.MAX_VALUE);
+    }
+
+    @ParameterizedTest
+    @RandomDoubleSource(min = 90.0, max = 100.0, count = 100)
+    void shouldProvideRandomDoublesWithCustomBounds(double value) {
+        assertThat(value).isBetween(90.0, 100.0);
+    }
+
+    private static RandomDoubleSource newRandomDoubleSource(double min, double max, int count) {
+        return new RandomDoubleSource() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return RandomDoubleSource.class;
+            }
+
+            @Override
+            public double min() {
+                return min;
+            }
+
+            @Override
+            public double max() {
+                return max;
+            }
+
+            @Override
+            public int count() {
+                return count;
+            }
+        };
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
@@ -45,13 +45,13 @@ class RandomLongArgumentsProviderTest {
 
     @ParameterizedTest
     @RandomLongSource
-    void shouldProvideRandomIntegersWithDefaultAnnotationValues(long value) {
+    void shouldProvideRandomLongsWithDefaultAnnotationValues(long value) {
         assertThat(value).isBetween(Long.MIN_VALUE, Long.MAX_VALUE);
     }
 
     @ParameterizedTest
     @RandomLongSource(min = 60, max = 70, count = 75)
-    void shouldProvideRandomIntegersWithCustomBounds(long value) {
+    void shouldProvideRandomLongsWithCustomBounds(long value) {
         assertThat(value).isBetween(60L, 70L);
     }
 


### PR DESCRIPTION
* Add RandomDoubleSource annotation
* Add RandomDoubleArgumentsProvider, which is the ArgumentsSource that
  generates the double values
* Fix test names in RandomLongArgumentsProviderTest (which I admit
  just might have been caused by a copy/paste from the
  RandomIntArgumentsProviderTest...again, it might have resulted from
  that...but I cannot confirm it or deny it)

Closes #199