### PR TITLE
Add assertions to HealthCheckResultAssertions for absence of details

### DIFF
--- a/src/main/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertions.java
+++ b/src/main/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertions.java
@@ -1,10 +1,17 @@
 package org.kiwiproject.test.assertj.dropwizard.metrics;
 
+import static java.util.stream.Collectors.joining;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.kiwiproject.collect.KiwiMaps.isNullOrEmpty;
+import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
+
 import com.codahale.metrics.health.HealthCheck;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.kiwiproject.base.KiwiStrings;
+
+import java.util.Arrays;
 
 /**
  * Provides for fluent {@link HealthCheck} tests using AssertJ assertions.
@@ -345,6 +352,49 @@ public class HealthCheckResultAssertions {
         Assertions.assertThat(result.getDetails())
                 .describedAs("Expected detail not found")
                 .containsEntry(key, value);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result does not contain the given key in its details.
+     *
+     * @param key the unexpected key
+     * @return this instance
+     */
+    public HealthCheckResultAssertions doesNotHaveDetailsContainingKey(String key) {
+        var details = result.getDetails();
+
+        if (isNullOrEmpty(details)) {
+            return this;
+        }
+
+        Assertions.assertThat(details)
+                .describedAs("Expected details not to contain key '%s'", key)
+                .doesNotContainKeys(key);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result does not contain any of the the given keys in its details.
+     *
+     * @param keys the unexpected keys
+     * @return this instance
+     */
+    public HealthCheckResultAssertions doesNotHaveDetailsContainingKeys(String... keys) {
+        var details = result.getDetails();
+
+        if (isNullOrEmpty(details)) {
+            return this;
+        }
+
+        var lazyKeysArg = lazy(() ->
+                Arrays.stream(keys).map(key -> f("'{}'", key)).collect(joining(", ")));
+
+        Assertions.assertThat(details)
+                .describedAs("Expected details not to contain keys: %s", lazyKeysArg)
+                .doesNotContainKeys(keys);
 
         return this;
     }

--- a/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
@@ -580,6 +583,96 @@ class HealthCheckResultAssertionsTest {
                                 .isHealthy()
                                 .hasNullOrEmptyDetails())
                         .hasMessageContaining("Expected null or empty details");
+            }
+        }
+
+        @Nested
+        class DoesNotHaveDetailsContainingKey {
+
+            @Test
+            void shouldPass_WhenDetailsAreNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKey("someKey"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldPass_WhenDetailsAreEmpty() {
+                var healthCheck = newHealthCheckWithEmptyDetails();
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKey("someKey"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldPass_WhenDetailsDoesNotContainGivenKey() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKey("numPages"))
+                        .doesNotThrowAnyException();
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"book", "author", "pubYear"})
+            void shouldFail_WhenDetailsContainsGivenKey(String key) {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKey(key))
+                        .hasMessageContaining("Expected details not to contain key '%s'", key);
+            }
+        }
+
+        @Nested
+        class DoesNotHaveDetailsContainingKeys {
+
+            @Test
+            void shouldPass_WhenDetailsAreNull() {
+                var healthCheck = newHealthCheckWithNullDetails();
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKeys("someKey", "anotherKey", "yetAnotherKey"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldPass_WhenDetailsAreEmpty() {
+                var healthCheck = newHealthCheckWithEmptyDetails();
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKeys("someKey", "anotherKey", "yetAnotherKey"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldPass_WhenDetailsDoesNotContainGivenKeys() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKeys("numPages", "publisher", "ISBN"))
+                        .doesNotThrowAnyException();
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                    "author, pubYear",
+                    "author, book",
+                    "book, pubYear"
+            })
+            void shouldFail_WhenDetailsContainsGivenKey(String key1, String key2) {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .isHealthy()
+                                .doesNotHaveDetailsContainingKeys(key1, key2))
+                        .hasMessageContaining("Expected details not to contain keys: '%s', '%s'", key1, key2);
             }
         }
     }


### PR DESCRIPTION
* Add new methods to HealthCheckResultAssertions to assert that the
  HealthCheck.Result details do NOT contain a single key or any of
  several keys

Closes #203