### PR TITLE
Add KiwiAssertJ methods to assert one element in collections and maps

### DIFF
--- a/src/main/java/org/kiwiproject/test/assertj/KiwiAssertJ.java
+++ b/src/main/java/org/kiwiproject/test/assertj/KiwiAssertJ.java
@@ -3,6 +3,9 @@ package org.kiwiproject.test.assertj;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import lombok.experimental.UtilityClass;
+import org.assertj.core.api.ObjectAssert;
+
+import java.util.Map;
 
 /**
  * Some AssertJ test utilities that you might or might find useful.
@@ -38,5 +41,52 @@ public class KiwiAssertJ {
     public static <T> T assertIsTypeOrSubtype(Object object, Class<T> type) {
         assertThat(object).isInstanceOf(type);
         return type.cast(object);
+    }
+
+    /**
+     * Assert the given Iterable contains exactly one element, and returns {@link ObjectAssert} for further
+     * AssertJ method chaining.
+     * <p>
+     * This is basically just a shortcut for {@code assertThat(iterable).hasSize(1).first()} but that seems to come up
+     * enough in testing (for me anyway) that I don't want to type it out every time.
+     *
+     * @param iterable the Iterable
+     * @param <T>      the type of element
+     * @return an {@link ObjectAssert} for further method chaining
+     */
+    public static <T> ObjectAssert<T> assertThatOnlyElementIn(Iterable<T> iterable) {
+        return assertThat(iterable)
+                .describedAs("Expected exactly one element")
+                .hasSize(1)
+                .first();
+    }
+
+    /**
+     * Assert the given Iterable contains exactly one element, and return that element for further inspection.
+     *
+     * @param iterable the Iterable
+     * @param <T>      the type of element
+     * @return the first element
+     */
+    public static <T> T assertAndGetOnlyElementIn(Iterable<T> iterable) {
+        assertThat(iterable)
+                .describedAs("Expected exactly one element")
+                .hasSize(1);
+        return iterable.iterator().next();
+    }
+
+    /**
+     * Assert the given Map contains exactly one entry, and return that entry for further inspection.
+     *
+     * @param map the Map
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     * @return the first entry
+     */
+    public static <K, V> Map.Entry<K, V> assertAndGetOnlyEntryIn(Map<K, V> map) {
+        assertThat(map)
+                .describedAs("Expected exactly one entry")
+                .hasSize(1);
+        return map.entrySet().iterator().next();
     }
 }

--- a/src/test/java/org/kiwiproject/test/assertj/KiwiAssertJTest.java
+++ b/src/test/java/org/kiwiproject/test/assertj/KiwiAssertJTest.java
@@ -1,11 +1,17 @@
 package org.kiwiproject.test.assertj;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @DisplayName("KiwiAssertJ")
 class KiwiAssertJTest {
@@ -55,6 +61,107 @@ class KiwiAssertJTest {
 
             assertThatThrownBy(() -> KiwiAssertJ.assertIsTypeOrSubtype(plane, Car.class))
                     .isInstanceOf(AssertionError.class);
+        }
+    }
+
+    @Nested
+    class AssertThatOnlyOneElementInIterable {
+
+        @Test
+        void shouldAcceptLists() {
+            var anakin = new Person();
+            var people = List.of(anakin);
+
+            KiwiAssertJ.assertThatOnlyElementIn(people).isSameAs(anakin);
+        }
+
+        @Test
+        void shouldAcceptSets() {
+            var kenobi = new Person();
+            var people = Set.of(kenobi);
+
+            KiwiAssertJ.assertThatOnlyElementIn(people).isSameAs(kenobi);
+        }
+
+        @Test
+        void shouldThrow_WhenIterable_HasNoElements() {
+            var emptySet = Collections.emptySortedSet();
+            assertThatThrownBy(() -> KiwiAssertJ.assertThatOnlyElementIn(emptySet))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("Expected exactly one element");
+        }
+
+        @Test
+        void shouldThrow_WhenIterable_HasMoreThanOneElement() {
+            var people = Set.of(new Person(), new Person());
+            assertThatThrownBy(() -> KiwiAssertJ.assertThatOnlyElementIn(people))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("Expected exactly one element");
+        }
+    }
+
+    @Nested
+    class AssertAndGetOnlyElementInIterable {
+
+        @Test
+        void shouldAcceptLists() {
+            var anakin = new Person();
+            var people = List.of(anakin);
+
+            var darth = KiwiAssertJ.assertAndGetOnlyElementIn(people);
+            assertThat(darth).isSameAs(anakin);
+        }
+
+        @Test
+        void shouldAcceptSets() {
+            var kenobi = new Person();
+            var people = Set.of(kenobi);
+
+            var formerMaster = KiwiAssertJ.assertAndGetOnlyElementIn(people);
+            assertThat(formerMaster).isSameAs(kenobi);
+        }
+
+        @Test
+        void shouldThrow_WhenIterable_HasNoElements() {
+            var emptySet = Collections.emptySortedSet();
+            assertThatThrownBy(() -> KiwiAssertJ.assertAndGetOnlyElementIn(emptySet))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("Expected exactly one element");
+        }
+
+        @Test
+        void shouldThrow_WhenIterable_HasMoreThanOneElement() {
+            var people = Set.of(new Person(), new Person());
+            assertThatThrownBy(() -> KiwiAssertJ.assertAndGetOnlyElementIn(people))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("Expected exactly one element");
+        }
+    }
+
+    @Nested
+    class AssertAndGetOnlyEntryInMap {
+
+        @Test
+        void shouldGetOnlyEntry() {
+            var map = Map.of("answer", 42);
+            var entry = KiwiAssertJ.assertAndGetOnlyEntryIn(map);
+            assertThat(entry).isEqualTo(entry("answer", 42));
+        }
+
+        @Test
+        void shouldThrowWhenMapIsEmpty() {
+            var emptyMap = Collections.emptyMap();
+            assertThatThrownBy(() -> KiwiAssertJ.assertAndGetOnlyEntryIn(emptyMap))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("Expected exactly one entry");
+        }
+
+        @Test
+        void shouldThrowWhenMapHasMoreThanOneEntry() {
+            var employees = Map.of("bob", new Employee(), "alice", new Employee());
+            assertThatThrownBy(() -> KiwiAssertJ.assertAndGetOnlyEntryIn(employees))
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("Expected exactly one entry");
         }
     }
 


### PR DESCRIPTION
* <T> ObjectAssert<T> assertThatOnlyElementIn(Iterable<T> iterable)
* <T> T assertAndGetOnlyElementIn(Iterable<T> iterable)
* <K, V> Map.Entry<K, V> assertAndGetOnlyEntryIn(Map<K, V> map)

The first method returns ObjectAssert for further method chaining.
The second and third methods simply assert the collection/map contains
exactly one element/entry and then returns that object.

Closes #205