### PR TITLE
Change test POM files to use fake dependencies to avoid dependabot check

### DIFF
--- a/src/test/java/org/kiwiproject/test/util/ServiceNamesTest.java
+++ b/src/test/java/org/kiwiproject/test/util/ServiceNamesTest.java
@@ -40,7 +40,6 @@ class ServiceNamesTest {
         })
         void shouldFindServiceOrEmulator(String path, String expectedName) {
             var rootPath = Path.of(basePath, path).toString();
-            System.out.println(rootPath);
             var name = ServiceNames.findServiceOrEmulatorNameFromRoot(rootPath);
             assertThat(name).isEqualTo(expectedName);
         }

--- a/src/test/resources/MongoTestsTest/pom.xml
+++ b/src/test/resources/MongoTestsTest/pom.xml
@@ -23,21 +23,21 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <groupId>com.goggle.tangerine</groupId>
+            <artifactId>tangerine</artifactId>
+            <version>42.0.42</version>
         </dependency>
 
         <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>kiwi</artifactId>
-            <version>0.7.0</version>
+            <groupId>com.acme</groupId>
+            <artifactId>fizzle-splits</artifactId>
+            <version>6.7.8</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <groupId>com.acme</groupId>
+            <artifactId>awesome-logging-api</artifactId>
+            <version>1.42.0</version>
         </dependency>
 
     </dependencies>

--- a/src/test/resources/ServiceNamesTest/nested-service/service/pom.xml
+++ b/src/test/resources/ServiceNamesTest/nested-service/service/pom.xml
@@ -23,21 +23,21 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <groupId>com.goggle.tangerine</groupId>
+            <artifactId>tangerine</artifactId>
+            <version>42.0.42</version>
         </dependency>
 
         <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>kiwi</artifactId>
-            <version>0.7.0</version>
+            <groupId>com.acme</groupId>
+            <artifactId>fizzle-splits</artifactId>
+            <version>6.7.8</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <groupId>com.acme</groupId>
+            <artifactId>awesome-logging-api</artifactId>
+            <version>1.42.0</version>
         </dependency>
 
     </dependencies>

--- a/src/test/resources/ServiceNamesTest/no-parent-pom/pom.xml
+++ b/src/test/resources/ServiceNamesTest/no-parent-pom/pom.xml
@@ -17,21 +17,21 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <groupId>com.goggle.tangerine</groupId>
+            <artifactId>tangerine</artifactId>
+            <version>42.0.42</version>
         </dependency>
 
         <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>kiwi</artifactId>
-            <version>0.7.0</version>
+            <groupId>com.acme</groupId>
+            <artifactId>fizzle-splits</artifactId>
+            <version>6.7.8</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <groupId>com.acme</groupId>
+            <artifactId>awesome-logging-api</artifactId>
+            <version>1.42.0</version>
         </dependency>
 
     </dependencies>

--- a/src/test/resources/ServiceNamesTest/top-level-app/pom.xml
+++ b/src/test/resources/ServiceNamesTest/top-level-app/pom.xml
@@ -23,21 +23,21 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <groupId>com.goggle.tangerine</groupId>
+            <artifactId>tangerine</artifactId>
+            <version>42.0.42</version>
         </dependency>
 
         <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>kiwi</artifactId>
-            <version>0.7.0</version>
+            <groupId>com.acme</groupId>
+            <artifactId>fizzle-splits</artifactId>
+            <version>6.7.8</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <groupId>com.acme</groupId>
+            <artifactId>awesome-logging-api</artifactId>
+            <version>1.42.0</version>
         </dependency>
 
     </dependencies>

--- a/src/test/resources/ServiceNamesTest/top-level-emulator/pom.xml
+++ b/src/test/resources/ServiceNamesTest/top-level-emulator/pom.xml
@@ -23,21 +23,21 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <groupId>com.goggle.tangerine</groupId>
+            <artifactId>tangerine</artifactId>
+            <version>42.0.42</version>
         </dependency>
 
         <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>kiwi</artifactId>
-            <version>0.7.0</version>
+            <groupId>com.acme</groupId>
+            <artifactId>fizzle-splits</artifactId>
+            <version>6.7.8</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <groupId>com.acme</groupId>
+            <artifactId>awesome-logging-api</artifactId>
+            <version>1.42.0</version>
         </dependency>
 
     </dependencies>

--- a/src/test/resources/ServiceNamesTest/top-level-service/pom.xml
+++ b/src/test/resources/ServiceNamesTest/top-level-service/pom.xml
@@ -23,21 +23,21 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <groupId>com.goggle.tangerine</groupId>
+            <artifactId>tangerine</artifactId>
+            <version>42.0.42</version>
         </dependency>
 
         <dependency>
-            <groupId>org.kiwiproject</groupId>
-            <artifactId>kiwi</artifactId>
-            <version>0.7.0</version>
+            <groupId>com.acme</groupId>
+            <artifactId>fizzle-splits</artifactId>
+            <version>6.7.8</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <groupId>com.acme</groupId>
+            <artifactId>awesome-logging-api</artifactId>
+            <version>1.42.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Dependabot notified us that a bunch of test pom.xml files had
vulnerable dependencies and submitted PRs. Rather than deal with this
again in the future, change the dependencies in the test POMS to fake
ones. Note these are all related to ServiceNamesTest.

Misc: removed a System.out.println from ServiceNamesTest