### PR TITLE
Sonar: Declare local variables with 'var' where type is clear

### DIFF
--- a/src/main/java/org/kiwiproject/test/curator/CuratorTestingServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/curator/CuratorTestingServerExtension.java
@@ -84,7 +84,7 @@ public class CuratorTestingServerExtension implements BeforeAllCallback, AfterAl
         } else if (client.getState() == CuratorFrameworkState.STOPPED) {
             LOG.trace("[beforeAll: {}] Re-initialize since client is STOPPED. There is probably more than one @Nested test class.",
                     displayName);
-            int newPort = findOpenPortOrThrow();
+            var newPort = findOpenPortOrThrow();
             initialize(newPort);
         }
 

--- a/src/main/java/org/kiwiproject/test/jaxrs/JaxrsTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/jaxrs/JaxrsTestHelper.java
@@ -368,7 +368,7 @@ public class JaxrsTestHelper {
      * @see Response#getEntity()
      */
     public static <T> T assertResponseEntity(Response response, Class<T> expectedClass, T expectedEntity) {
-        T entity = assertNonNullResponseEntity(response, expectedClass);
+        var entity = assertNonNullResponseEntity(response, expectedClass);
         assertThat(entity).isSameAs(expectedEntity);
         return entity;
     }

--- a/src/main/java/org/kiwiproject/test/junit/ParameterizedTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/junit/ParameterizedTestHelper.java
@@ -92,9 +92,9 @@ public class ParameterizedTestHelper {
         checkArgumentNotNull(resultSupplier);
 
         indicesOf(inputValues).forEach(index -> {
-            T input = inputValues.get(index);
+            var input = inputValues.get(index);
             mutator.accept(input);
-            R result = resultSupplier.get();
+            var result = resultSupplier.get();
             softly.assertThat(result)
                     .describedAs("input: [%s]", input)
                     .isEqualTo(expectedResults.get(index));
@@ -135,10 +135,9 @@ public class ParameterizedTestHelper {
         checkInputsAndExpectedResults(inputValues, expectedResults);
         checkArgumentNotNull(function);
 
-        // TODO: When kiwi 0.23.0 is released, switch this to the kiwi version
         indicesOf(inputValues).forEach(index -> {
-            T input = inputValues.get(index);
-            R result = function.apply(input);
+            var input = inputValues.get(index);
+            var result = function.apply(input);
             softly.assertThat(result)
                     .describedAs("input: [%s]", input)
                     .isEqualTo(expectedResults.get(index));

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -276,7 +276,7 @@ public class MongoTestProperties {
      * @throws IllegalArgumentException if the databaseName is blank or does not have any underscores
      */
     public static String databaseNameWithoutTimestamp(String databaseName) {
-        int lastUnderscoreIndex = getLastUnderscoreIndex(databaseName);
+        var lastUnderscoreIndex = getLastUnderscoreIndex(databaseName);
         return databaseName.substring(0, lastUnderscoreIndex);
     }
 
@@ -305,7 +305,7 @@ public class MongoTestProperties {
      * @throws NumberFormatException    if the extracted "timestamp" cannot be parsed into a {@code long}
      */
     public static long extractDatabaseTimestamp(String databaseName) {
-        int lastUnderscoreIndex = getLastUnderscoreIndex(databaseName);
+        var lastUnderscoreIndex = getLastUnderscoreIndex(databaseName);
         return Long.parseLong(databaseName.substring(lastUnderscoreIndex + 1));
     }
 

--- a/src/main/java/org/kiwiproject/test/util/ServiceNames.java
+++ b/src/main/java/org/kiwiproject/test/util/ServiceNames.java
@@ -12,7 +12,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * This utility class helps find service or emulator names from Maven POM files. It is useful only if you need to
@@ -102,7 +101,7 @@ public class ServiceNames {
      * @throws IllegalStateException if no parent element is found in the POM
      */
     public static String findServiceOrEmulatorNameInPom(Path pomPath) throws IOException {
-        try (Stream<String> lineStream = Files.lines(pomPath)) {
+        try (var lineStream = Files.lines(pomPath)) {
             var lines = lineStream.collect(toUnmodifiableList());
             checkParentTagExists(lines);
             var artifactIds = findFirstTwoArtifactIdTags(lines);

--- a/src/main/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelper.java
@@ -147,7 +147,7 @@ public class ParameterizedValidationTestHelper {
         checkInputAndExpectedValues(inputValues, expectedViolations, "expectedViolations");
 
         indicesOf(inputValues).forEach(index -> {
-            T input = inputValues.get(index);
+            var input = inputValues.get(index);
             mutator.accept(input);
             var violations = validator.validateProperty(object, propertyName, groups);
             softly.assertThat(violations)
@@ -203,9 +203,8 @@ public class ParameterizedValidationTestHelper {
         checkArgumentNotNull(propertyName);
         checkInputAndExpectedValues(inputValues, expectedViolationMessages, "expectedViolationMessages");
 
-        // TODO: When kiwi 0.23.0 is released, switch this to the kiwi version
         indicesOf(inputValues).forEach(index -> {
-            T input = inputValues.get(index);
+            var input = inputValues.get(index);
             mutator.accept(input);
             var violations = validator.validateProperty(object, propertyName, groups);
             softly.assertThat(violations)

--- a/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
@@ -565,7 +565,7 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                MockHealthCheck healthCheck = newHealthCheckWithEmptyDetails();
+                var healthCheck = newMockHealthCheckWithEmptyDetails();
 
                 assertThatCode(() ->
                         assertThat(healthCheck)
@@ -601,7 +601,7 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                var healthCheck = newHealthCheckWithEmptyDetails();
+                var healthCheck = newMockHealthCheckWithEmptyDetails();
                 assertThatCode(() ->
                         assertThat(healthCheck)
                                 .isHealthy()
@@ -644,7 +644,7 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                var healthCheck = newHealthCheckWithEmptyDetails();
+                var healthCheck = newMockHealthCheckWithEmptyDetails();
                 assertThatCode(() ->
                         assertThat(healthCheck)
                                 .isHealthy()
@@ -693,7 +693,7 @@ class HealthCheckResultAssertionsTest {
         };
     }
 
-    private MockHealthCheck newHealthCheckWithEmptyDetails() {
+    private MockHealthCheck newMockHealthCheckWithEmptyDetails() {
         var healthCheck = MockHealthCheck.builder().build();
         var result = healthCheck.execute();
         var details = result.getDetails();

--- a/src/test/java/org/kiwiproject/test/json/LoggingDeserializationTestHandlerTest.java
+++ b/src/test/java/org/kiwiproject/test/json/LoggingDeserializationTestHandlerTest.java
@@ -33,7 +33,7 @@ class LoggingDeserializationTestHandlerTest {
     void shouldCountEveryUnknownProperty() {
         ensureFailOnUnknownPropertiesIsDisabled();
 
-        int numTimes = 10;
+        var numTimes = 10;
         IntStream.rangeClosed(1, numTimes).forEach(ignored -> jsonHelper.copy(new Foo(), Bar.class));
 
         assertThat(handler.getErrorCount()).isEqualTo(numTimes);

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/AsyncModeDisablingExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/AsyncModeDisablingExtensionTest.java
@@ -17,15 +17,15 @@ class AsyncModeDisablingExtensionTest {
 
     @Test
     void shouldDisableAsyncModeDuringThisTest() {
-        int sleepTime = 100;
-        long startNanos = System.nanoTime();
+        var sleepTime = 100L;
+        var startNanos = System.nanoTime();
         Async.doAsync(() -> {
             new DefaultEnvironment().sleepQuietly(sleepTime, TimeUnit.MILLISECONDS);
             return 42;
         });
 
-        long elapsedNanos = System.nanoTime() - startNanos;
-        long elapsedMillis = Duration.ofNanos(elapsedNanos).toMillis();
+        var elapsedNanos = System.nanoTime() - startNanos;
+        var elapsedMillis = Duration.ofNanos(elapsedNanos).toMillis();
         LOG.info("Elapsed time: {} millis", elapsedMillis);
 
         assertThat(elapsedMillis)


### PR DESCRIPTION
* Change more local variable declarations to use 'var' instead of the
  explicit type, where the type is clear
* Remove a few TODOs that I forgot to remove in the previous commit
  in ParameterizedTestHelper and ParameterizedValidationTestHelper