### PR TITLE
Bump kiwi from 0.25.0 to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,17 +29,17 @@
     <properties>
         <!-- Versions for required dependencies -->
         <guava.version>30.1.1-jre</guava.version>
-        <kiwi.version>0.25.0</kiwi.version>
+        <kiwi.version>1.0.0</kiwi.version>
 
         <!-- Versions for provided dependencies -->
-        <byte.buddy.version>[1.10.20,1.12.0)</byte.buddy.version>
+        <byte.buddy.version>[1.11.14,1.12.0)</byte.buddy.version>
         <commons-text.version>1.9</commons-text.version>
         <curator.version>5.1.0</curator.version>
         <dropwizard.version>2.0.25</dropwizard.version>
         <dropwizard.metrics.version>4.1.25</dropwizard.metrics.version>
-        <embedded-postgres.version>1.3.0</embedded-postgres.version>
+        <embedded-postgres.version>1.3.1</embedded-postgres.version>
         <h2.version>1.4.200</h2.version>
-        <hibernate.version>5.5.3.Final</hibernate.version>
+        <hibernate.version>5.5.7.Final</hibernate.version>
         <hibernate-validator.version>6.1.7.Final</hibernate-validator.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta-el.version>3.0.4</jakarta-el.version>
@@ -56,7 +56,7 @@
         <zookeeper.version>3.7.0</zookeeper.version>
 
         <!-- Versions for optional dependencies -->
-        <error_prone_annotations.version>2.8.0</error_prone_annotations.version>
+        <error_prone_annotations.version>2.9.0</error_prone_annotations.version>
 
         <!-- Versions for test dependencies -->
         <mongo-java-server.version>1.38.0</mongo-java-server.version>


### PR DESCRIPTION
* Bump kiwi from 0.25.0 to 1.0.0
* Bump byte-buddy start version from 1.10.20 to 1.11.14
* Bump embedded-postgres from 1.3.0 to 1.3.1
* Bump hibernate from 5.5.3.Final to 5.5.7.Final
* Bump error_prone_annotations from 2.7.1 to 2.8.0