### PR TITLE
Add slf4j-api and logback-classic dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>kiwi</artifactId>
             <version>${kiwi.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <!-- provided dependencies -->
 
@@ -197,6 +202,14 @@
             <groupId>de.bwaldvogel</groupId>
             <artifactId>mongo-java-server</artifactId>
             <scope>provided</scope>
+        </dependency>
+        
+        <!-- test dependencies -->
+        
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
* Add slf4j-api and logback-classic as explicit dependencies in the POM
  since kiwi-parent 2.0.0 removed them.