### PR TITLE
PostgresAppTestExtension enhancements

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
@@ -13,26 +13,34 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.postgresql.Driver;
 
 /**
- * Multi-purpose extension for {@link Application} testing requiring a PostgreSQL database. The extension will spin up an
- * embedded PostgreSQL database instance, run the migrations and then configure the {@link DropwizardAppExtension} with the
- * database information.
+ * Multipurpose extension for Dropwizard {@link Application} testing requiring a PostgreSQL database. The extension
+ * will spin up an embedded PostgreSQL database instance, run the migrations and then configure the
+ * {@link DropwizardAppExtension} with the database information.
  * <p>
- * Currently, this extension has a few limitations/caveats:
+ * There are several things to note when using this extension:
  * <ul>
  *     <li>
- *         The embedded PostgreSQL extension supports both Flyway and Liquibase, but we are assuming migrations are Liquibase.
+ *         The embedded PostgreSQL extension supports both Flyway and Liquibase, but we are only supporting Liquibase
+ *         currently.
  *     </li>
  *     <li>
  *         The application's {@link Configuration} class must have a Dropwizard
- *         {@link io.dropwizard.db.DataSourceFactory DataSourceFactory} with JSON its property name as "database",
- *         i.e. the property will either have {@code @JsonProperty("database")} or be named "database"
+ *         {@link io.dropwizard.db.DataSourceFactory DataSourceFactory}. By default the property name is expected to
+ *         be "database", i.e. the property will either have {@code @JsonProperty("database")} or be named "database",
+ *         but you can change this using the alternate constructor.
  *      </li>
  *      <li>
- *          The YAML configuration file provided to this extension must contain a {@code database} property that
- *          contains a {@code driverClass} with the string value: {@code org.postgresql.Driver} (this corresponds to
- *          the "database" property mentioned above which defines the {@code DataSourceFactory})
+ *          The YAML configuration file provided to this extension can contain a
+ *          {@link io.dropwizard.db.DataSourceFactory DataSourceFactory} property with custom values, but this extension
+ *          always overrides the following properties: {@code driverClass}, {@code user}, and {@code url} because the
+ *          driver is always Postgres, and the user and url are provided by the embedded Postgres database.
+ *      </li>
+ *      <li>
+ *          You should <strong>not</strong> register {@code DropwizardExtensionsSupport} or the embedded Postgres
+ *          extension. See the WARNING below.
  *      </li>
  * </ul>
  * <p>
@@ -42,19 +50,43 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *  public static PostgresAppTestExtension&lt;AppConfiguration&gt; POSTGRES_APP =
  *      new PostgresAppTestExtension("migrations.xml", "config.yml", App.class);
  * </pre>
- * Here is a sample {@code config.yml}:
+ * Here is a one of the simplest {@code config.yml} files you can have:
  * <pre>
  * ---
- * database:
- *   driverClass: org.postgresql.Driver
+ * server:
+ *  type: simple
  * </pre>
- * And here is a fragment of a sample Configuration class:
+ * Note that you do <strong>not</strong> need to declare a database property because this extension overrides the
+ * required properties. But, you can add other custom properties to the configuration if desired:
+ * <pre>
+ * ---
+ * server:
+ *  type: simple
+ *
+ * database:
+ *   initialSize: 1
+ *   minSize: 1
+ *   maxSize: 5
+ * </pre>
+ * <p>
+ * Most of the time these won't really matter in unit/integration testing scenarios. Next is a fragment of a sample
+ * Configuration class that uses the default property name:
  * <pre>
  * {@literal @}JsonProperty("database")
  *  private DataSourceFactory dataSourceFactory = new DataSourceFactory();
  * </pre>
+ * The extension assumes the configuration uses {@code "database"} as the name of the DataSourceFactory property, as
+ * shown in the above examples which specify the name via the {@code JsonProperty} annotation. If the property in
+ * your configuration is named something else, you can use the alternate constructor which accepts a custom property
+ * name. For example:
+ * <pre>
+ *  // Uses "db" as the name of the DataSourceFactory in the configuration
+ * {@literal @}RegisterExtension
+ *  public static PostgresAppTestExtension&lt;AppConfiguration&gt; POSTGRES_APP =
+ *      new PostgresAppTestExtension("migrations.xml", "config.yml", App.class, "db");
+ * </pre>
  * <p>
- * The test extension instance will have access to the application and the PostgreSQL instance by calling
+ * The test extension instance can access the application and the PostgreSQL instance by calling
  * {@code POSTGRES_APP.getApp()} and {@code POSTGRES_APP.getPostgres()} respectively.
  * <p>
  * You can also provide one or more {@link ConfigOverride} values to the extension:
@@ -66,9 +98,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *          ConfigOverride.config("aLazyValue", () -&gt; calculateTheLazyValue()));
  * </pre>
  * <p>
- * WARNING: When using this extension you should <strong>not</strong> register {@code DropwizardExtensionsSupport} or
- * the embedded Postgres extension since this extension programmatically registers both of them. Doing so will almost
- * certainly result in unexpected behavior such as {@code NullPointerException}s being thrown.
+ * <strong>WARNING</strong>: When using this extension you should <strong>not</strong> register
+ * {@code DropwizardExtensionsSupport} or the embedded Postgres extension since this extension programmatically
+ * registers both of them. Doing so will almost certainly result in unexpected behavior such as
+ * {@code NullPointerException}s being thrown.
  * <p>
  * For information on how the embedded PostgreSQL extension works see:
  * <a href="https://github.com/zonkyio/embedded-postgres">https://github.com/zonkyio/embedded-postgres</a>
@@ -81,11 +114,13 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 @Getter
 public class PostgresAppTestExtension<T extends Configuration> implements BeforeAllCallback, AfterAllCallback {
 
+    private static final String DEFAULT_DATASOURCE_FACTORY_PROPERTY = "database";
+
     private final PreparedDbExtension postgres;
     private final DropwizardAppExtension<T> app;
 
     /**
-     * Create a new instance.
+     * Create a new instance using the default property name ("database") for the DataSourceFactory.
      *
      * @param migrationClasspathLocation the classpath location of the Liquibase migrations file to use
      * @param configFileName             the name of the classpath resource to use as the application configuration file
@@ -97,15 +132,40 @@ public class PostgresAppTestExtension<T extends Configuration> implements Before
                                     Class<? extends Application<T>> appClass,
                                     ConfigOverride... configOverrides) {
 
+        this(migrationClasspathLocation, configFileName, appClass, DEFAULT_DATASOURCE_FACTORY_PROPERTY, configOverrides);
+    }
+
+    /**
+     * Create a new instance with a custom property name for the DataSourceFactory.
+     *
+     * @param migrationClasspathLocation    the classpath location of the Liquibase migrations file to use
+     * @param configFileName                the name of the classpath resource to use as the application
+     *                                      configuration file
+     * @param appClass                      the Dropwizard application class
+     * @param dataSourceFactoryPropertyName the name of the DataSourceFactory property in the Configuration class,
+     *                                      i.e. what is specified in the YAML configuration
+     * @param configOverrides               optional configuration override values
+     */
+    public PostgresAppTestExtension(String migrationClasspathLocation,
+                                    String configFileName,
+                                    Class<? extends Application<T>> appClass,
+                                    String dataSourceFactoryPropertyName,
+                                    ConfigOverride... configOverrides) {
+
         var liquibasePreparer = LiquibasePreparer.forClasspathLocation(migrationClasspathLocation);
         postgres = EmbeddedPostgresExtension.preparedDatabase(liquibasePreparer);
 
-        var userConfigOverride = ConfigOverride.config("database.user", () -> postgres.getConnectionInfo().getUser());
-        var urlConfigOverride = ConfigOverride.config("database.url",
+        var dbUserProperty = dataSourceFactoryPropertyName + ".user";
+        var dbUrlProperty = dataSourceFactoryPropertyName + ".url";
+        var dbDriverClassProperty = dataSourceFactoryPropertyName + ".driverClass";
+
+        var userConfigOverride = ConfigOverride.config(dbUserProperty, () -> postgres.getConnectionInfo().getUser());
+        var urlConfigOverride = ConfigOverride.config(dbUrlProperty,
                 () -> "jdbc:postgresql://localhost:" + postgres.getConnectionInfo().getPort()
                         + "/" + postgres.getConnectionInfo().getDbName());
+        var driverConfigOverride = ConfigOverride.config(dbDriverClassProperty, Driver.class.getName());
 
-        var postgresConfigOverrides = new ConfigOverride[]{userConfigOverride, urlConfigOverride};
+        var postgresConfigOverrides = new ConfigOverride[]{userConfigOverride, urlConfigOverride, driverConfigOverride};
         var combinedConfigOverrides = ArrayUtils.addAll(postgresConfigOverrides, configOverrides);
 
         app = new DropwizardAppExtension<>(

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
@@ -1,0 +1,70 @@
+package org.kiwiproject.test.dropwizard.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.setup.Environment;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Tests that we can specify a custom name in the configuration for the DataSourceFactory.
+ */
+@DisplayName("PostgresAppTestExtension (custom DataSourceFactory property")
+class PostgresAppTestExtensionCustomPropertyTest {
+
+    @Getter
+    @Setter
+    static class Config extends Configuration {
+        @Valid
+        @NotNull
+        @JsonProperty("db")
+        private DataSourceFactory dataSourceFactory = new DataSourceFactory();
+    }
+
+    public static class App extends Application<Config> {
+        @Override
+        public void run(Config config, Environment environment) {
+            // Nothing to really do
+        }
+    }
+
+    private static final PostgresAppTestExtension<Config> EXTENSION = new PostgresAppTestExtension<>(
+            "PostgresAppTestExtensionTest/test-migrations.xml",
+            "PostgresAppTestExtensionTest/test-config.yml",
+            App.class, "db"
+    );
+
+    private static ExtensionContext mockContext;
+
+    @BeforeAll
+    static void setupAndStartExtension() throws Exception {
+        mockContext = mock(ExtensionContext.class);
+        EXTENSION.beforeAll(mockContext);
+    }
+
+    @AfterAll
+    static void stopExtension() {
+        EXTENSION.afterAll(mockContext);
+    }
+
+    @Test
+    void shouldStartPostgresAndApp() {
+        assertThat(EXTENSION.getApp()).isNotNull();
+        assertThat(EXTENSION.getApp().getTestSupport().getEnvironment()).isNotNull();
+        assertThat(EXTENSION.getPostgres()).isNotNull();
+        assertThat(EXTENSION.getPostgres().getTestDatabase()).isNotNull();
+    }
+}

--- a/src/test/resources/PostgresAppTestExtensionTest/test-config.yml
+++ b/src/test/resources/PostgresAppTestExtensionTest/test-config.yml
@@ -3,6 +3,3 @@ server:
   connector:
     type: http
     port: 10000
-
-database:
-  driverClass: org.postgresql.Driver


### PR DESCRIPTION
* Improve documentation
* Add constructor with dataSourceFactoryPropertyName parameter that
  specifies the name of the DataSourceFactory in the YAML configuration
* Eliminate the requirement to specify the driverClass in the YAML
  configuration, since we know it must always be org.postgresql.Driver.
  So, the extension will now always set the driverClass. This means
  there does not even need to be a "database" in the configuration
  unless you want to specify additional configuration parameters.

Closes #301