### PR TITLE
Add value attribute to ClearBoxTest annotation

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ClearBoxTest.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ClearBoxTest.java
@@ -19,4 +19,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Test
 public @interface ClearBoxTest {
+
+    /**
+     * Optional description or explanation why this is a "clear box" test.
+     */
+    String value() default "";
 }

--- a/src/test/java/org/kiwiproject/test/util/FixturesTest.java
+++ b/src/test/java/org/kiwiproject/test/util/FixturesTest.java
@@ -64,7 +64,7 @@ class FixturesTest {
         @Nested
         class UncheckedIOExceptionOrOriginalError {
 
-            @ClearBoxTest
+            @ClearBoxTest("non-public API")
             void shouldReturnTheOriginalError_WhenIt_HasNoCause() {
                 var error = new Error();
                 assertThat(Fixtures.uncheckedIOExceptionOrOriginalError(error, PANGRAM_FIXTURE))


### PR DESCRIPTION
This permits adding descriptions and/or explanations as to why a test
is a "clear box" test.

Used it once in FixturesTest, to "test" it.

Closes #310