### PR TITLE
Add MinimalBlankStringSource and MinimalBlankStringArgumentsProvider

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringSource.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringSource.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * @see AsciiOnlyBlankStringSource
+ * @see MinimalBlankStringSource
  */
 @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProvider.java
@@ -1,0 +1,45 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static java.util.Collections.unmodifiableList;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Creates an {@link ArgumentsProvider} that can feed a test method with multiple blank {@link String} objects for a
+ * {@link org.junit.jupiter.params.ParameterizedTest ParameterizedTest}. This will generate a limited number of blank
+ * strings including null and empty strings, and a few whitespace-only strings.
+ * <p>
+ * Usage:
+ * <pre>
+ * {@literal @}ParameterizedTest
+ * {@literal @}ArgumentsSource(MinimalBlankStringArgumentsProvider.class)
+ *  void testThatEachProvidedArgumentIsBlank(String blankString) {
+ *      assertThat(blankString).isBlank();
+ *      // or whatever else you need to test where you need a blank String...
+ *  }
+ * </pre>
+ * <p>
+ * For convenience, we recommend using the {@link MinimalBlankStringSource} annotation on parameterized tests.
+ *
+ * @see MinimalBlankStringSource
+ */
+public class MinimalBlankStringArgumentsProvider implements ArgumentsProvider {
+
+    /**
+     * A limited number of null, empty, or whitespace-only Strings.
+     */
+    public static final List<String> BLANK_STRINGS = unmodifiableList(
+            Arrays.asList(null, "", " ", "\t", "\n", "\r")
+    );
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return BLANK_STRINGS.stream().map(Arguments::of);
+    }
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringSource.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringSource.java
@@ -9,12 +9,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@code @AsciiOnlyBlankStringSource} is an {@link ArgumentsSource} which provides ASCII blank strings.
+ * {@code @MinimalBlankStringSource} is an {@link ArgumentsSource} which provides a few blank strings including
+ * null, zero-length string, strings with only spaces, and strings with only newline, carriage return, and tab.
+ *
  * <p>
  * Usage:
  * <pre>
  * {@literal @}ParameterizedTest
- * {@literal @}AsciiOnlyBlankStringSource
+ * {@literal @}MinimalBlankStringSource
  *  void testThatEachProvidedArgumentIsBlank(String blankString) {
  *      assertThat(blankString).isBlank();
  *      // or whatever else you need to test where you need a blank String...
@@ -22,11 +24,11 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * @see BlankStringSource
- * @see MinimalBlankStringSource
+ * @see AsciiOnlyBlankStringSource
  */
 @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@ArgumentsSource(AsciiOnlyBlankStringArgumentsProvider.class)
-public @interface AsciiOnlyBlankStringSource {
+@ArgumentsSource(MinimalBlankStringArgumentsProvider.class)
+public @interface MinimalBlankStringSource {
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProviderTest.java
@@ -1,0 +1,43 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@DisplayName("MinimalBlankStringArgumentsProvider")
+class MinimalBlankStringArgumentsProviderTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(MinimalBlankStringArgumentsProvider.class)
+    void shouldProvideBlankArguments(String blankString) {
+        assertThat(blankString).isBlank();
+
+        if (nonNull(blankString)) {
+            assertOnlyCharactersIn(blankString);
+        }
+    }
+
+    @ParameterizedTest
+    @MinimalBlankStringSource
+    void shouldProvideBlankArgumentsUsingAnnotation(String blankString) {
+        assertThat(blankString).isBlank();
+
+        if (nonNull(blankString)) {
+            assertOnlyCharactersIn(blankString);
+        }
+    }
+
+    private static void assertOnlyCharactersIn(String blankString) {
+        blankString.chars().forEach(charValue ->
+                assertThat(charValue)
+                        .isIn(
+                                9,  // tab
+                                10,  // newline
+                                13,  // carriage return
+                                32  // space
+                        ));
+    }
+}


### PR DESCRIPTION
* MinimalBlankStringArgumentsProvider is a Jupiter ArgumentsProvider
  that provides a limited number of common blank string values
* MinimalBlankStringSource is a Jupiter ArgumentsSource annotation
  allowing for a nicer "look" in tests
* Cross-reference MinimalBlankStringSource in AsciiOnlyBlankStringSource
  and BlankStringSource javadocs

Closes #318