### PR TITLE
Overload isNear methods in JavaTimeArgumentMatchers with ZonedDateTime

### DIFF
--- a/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
@@ -11,6 +11,8 @@ import org.mockito.ArgumentMatcher;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Static utility methods to create {@link ArgumentMatcher} instances for types in the {@code java.time} package.
@@ -20,6 +22,85 @@ import java.time.Instant;
 public class JavaTimeArgumentMatchers {
 
     private static final int DEFAULT_SLACK_MILLIS = 500;
+    private static final String EXPECTED_TIME_CANNOT_BE_NULL = "expectedTime cannot be null";
+    private static final String SLACK_CANNOT_BE_NULL = "slack cannot be null";
+
+    /**
+     * Matches an {@link ZonedDateTime} near the given expected time within +/- 500 milliseconds.
+     * <p>
+     * In other words, the actual time must be in the range {@code [ expectedTime - 500ms , expectedTime + 500ms ]}.
+     * <p>
+     * Example usage:
+     * <pre>
+     * // Assume a Timekeeper class contains an announceTime(ZonedDateTime time) method
+     * var expectedTime = determineExpectedZonedDateTime();
+     * verify(timekeeper).announceTime(argThat(isNear(expectedTime));
+     * </pre>
+     *
+     * @param expectedTime the expected time
+     * @return a new {@link ArgumentMatcher} instance
+     */
+    public static ArgumentMatcher<ZonedDateTime> isNear(ZonedDateTime expectedTime) {
+        return isNear(expectedTime, DEFAULT_SLACK_MILLIS);
+    }
+
+    /**
+     * Matches an {@link ZonedDateTime} near the given expected time within +/- {@code slack} duration.
+     * <p>
+     * In other words, the actual time must be in the range {@code [ expectedTime - slack , expectedTime + slack ]}.
+     * <p>
+     * Example usage:
+     * <pre>
+     * // Assume a Timekeeper class contains an announceTime(ZonedDateTime time) method
+     * var expectedTime = determineExpectedZonedDateTime();
+     * var slack = Duration.ofMillis(250)
+     * verify(timekeeper).announceTime(argThat(isNear(expectedTime, slack));
+     * </pre>
+     *
+     * @param expectedTime the expected time
+     * @param slack        the amount of time the actual time can differ before or after the expected time
+     * @return a new {@link ArgumentMatcher} instance
+     */
+    public static ArgumentMatcher<ZonedDateTime> isNear(ZonedDateTime expectedTime, Duration slack) {
+        checkArgumentNotNull(slack, SLACK_CANNOT_BE_NULL);
+        return isNear(expectedTime, slack.toMillis());
+    }
+
+    /**
+     * Matches an {@link ZonedDateTime} near the given expected time within +/- {@code slack} milliseconds.
+     * <p>
+     * In other words, the actual time must be in the range {@code [ expectedTime - slackMillis , expectedTime + slackMillis ]}.
+     * <pre>
+     * // Assume a Timekeeper class contains an announceTime(ZonedDateTime time) method
+     * var expectedTime = determineExpectedZonedDateTime();
+     * var slackMillis = 300;
+     * verify(timekeeper).announceTime(argThat(isNear(expectedTime, slackMillis));
+     * </pre>
+     *
+     * @param expectedTime the expected time
+     * @param slackMillis  the number of milliseconds the actual time can differ before or after the expected time
+     * @return a new {@link ArgumentMatcher} instance
+     */
+    public static ArgumentMatcher<ZonedDateTime> isNear(ZonedDateTime expectedTime, long slackMillis) {
+        checkArgumentNotNull(expectedTime, EXPECTED_TIME_CANNOT_BE_NULL);
+        checkPositive(slackMillis);
+
+        return actualTime -> {
+            LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}",
+                    expectedTime,
+                    actualTime,
+                    lazy(() -> Duration.between(expectedTime, actualTime)));
+
+            var lowerBound = expectedTime.minus(slackMillis, ChronoUnit.MILLIS);
+            var upperBound = expectedTime.plus(slackMillis, ChronoUnit.MILLIS);
+
+            assertThat(actualTime)
+                    .describedAs("actual time %s not between [ %s, %s ]", actualTime, lowerBound, upperBound)
+                    .isBetween(lowerBound, upperBound);
+
+            return true;
+        };
+    }
 
     /**
      * Matches an {@link Instant} near the given expected time within +/- 500 milliseconds.
@@ -58,7 +139,7 @@ public class JavaTimeArgumentMatchers {
      * @return a new {@link ArgumentMatcher} instance
      */
     public static ArgumentMatcher<Instant> isNear(Instant expectedTime, Duration slack) {
-        checkArgumentNotNull(slack, "slack cannot be null");
+        checkArgumentNotNull(slack, SLACK_CANNOT_BE_NULL);
 
         return isNear(expectedTime, slack.toMillis());
     }
@@ -79,7 +160,7 @@ public class JavaTimeArgumentMatchers {
      * @return a new {@link ArgumentMatcher} instance
      */
     public static ArgumentMatcher<Instant> isNear(Instant expectedTime, long slackMillis) {
-        checkArgumentNotNull(expectedTime, "expectedTime cannot be null");
+        checkArgumentNotNull(expectedTime, EXPECTED_TIME_CANNOT_BE_NULL);
         checkPositive(slackMillis);
 
         return actualTime -> {

--- a/src/test/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchersTest.java
+++ b/src/test/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchersTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 @DisplayName("JavaTimeArgumentMatchers")
 class JavaTimeArgumentMatchersTest {
@@ -39,10 +41,13 @@ class JavaTimeArgumentMatchersTest {
         @Test
         void shouldNotAllowNullInstant() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear(null));
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear((Instant) null));
 
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear(null, 500));
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear((Instant) null, Duration.ofMillis(100)));
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear((Instant) null, 500));
         }
 
         @Test
@@ -133,10 +138,126 @@ class JavaTimeArgumentMatchersTest {
         }
     }
 
+    @Nested
+    class IsNearZonedDateTime {
+
+        private Timekeeper timekeeper;
+
+        @BeforeEach
+        void setUp() {
+            timekeeper = mock(Timekeeper.class);
+            when(timekeeper.announce(any(ZonedDateTime.class)))
+                    .thenReturn("The time is now 2022-07-10T16:28:08.934789-04:00[America/New_York]");
+        }
+
+        @Test
+        void shouldNotAllowNullZonedDateTime() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear((ZonedDateTime) null));
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear((ZonedDateTime) null, Duration.ofMillis(250)));
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear((ZonedDateTime) null, 500));
+        }
+
+        @Test
+        void shouldNotAllowNullSlack() {
+            var now = ZonedDateTime.now();
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear(now, null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {-100, -1, 0})
+        void shouldRequirePositiveSlackMillis(long slackMillis) {
+            var now = ZonedDateTime.now();
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> JavaTimeArgumentMatchers.isNear(now, slackMillis));
+        }
+
+        @Nested
+        class UsingDefaultSlack {
+
+            @ParameterizedTest
+            @ValueSource(longs = {-500, -250, 0, 250, 500})
+            void shouldSucceed_WhenWithinExpectedTime_PlusOrMinusSlack(long millis) {
+                var zonedDateTime = callAnnounce(millis);
+
+                assertThatCode(() -> verify(timekeeper).announce(argThat(isNear(zonedDateTime))))
+                        .doesNotThrowAnyException();
+            }
+
+            @ParameterizedTest
+            @ValueSource(longs = {-1000, -501, 501, 1000})
+            void shouldFail_WhenOutsideExpectedTime_PlusOrMinusSlack(long millis) {
+                var zonedDateTime = callAnnounce(millis);
+
+                assertThatThrownBy(() -> verify(timekeeper).announce(argThat(isNear(zonedDateTime))))
+                        .isInstanceOf(AssertionError.class);
+            }
+        }
+
+        @Nested
+        class UsingCustomSlack {
+
+            @ParameterizedTest
+            @CsvSource({
+                    "-1000, 1000",
+                    "-750, 750",
+                    "-100, 100",
+                    "-50, 100",
+                    "0, 250",
+                    "50, 100",
+                    "100, 100",
+                    "300, 500",
+                    "750, 750",
+                    "750, 1000",
+            })
+            void shouldSucceed_WhenWithinExpectedTime_PlusOrMinusSlack(long millis, long slackMillis) {
+                var zonedDateTime = callAnnounce(millis);
+
+                var slack = Duration.ofMillis(slackMillis);
+                assertThatCode(() -> verify(timekeeper).announce(argThat(isNear(zonedDateTime, slack))))
+                        .doesNotThrowAnyException();
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                    "-1001, 1000",
+                    "-751, 750",
+                    "-101, 100",
+                    "101, 100",
+                    "301, 300",
+                    "751, 750",
+                    "1001, 1000",
+            })
+            void shouldFail_WhenOutsideExpectedTime_PlusOrMinusSlack(long millis, long slackMillis) {
+                var zonedDateTime = callAnnounce(millis);
+
+                var slack = Duration.ofMillis(slackMillis);
+                assertThatThrownBy(() -> verify(timekeeper).announce(argThat(isNear(zonedDateTime, slack))))
+                        .isInstanceOf(AssertionError.class);
+            }
+        }
+
+        // Call util.announce with the argument as (now + millisToAdd)
+        private ZonedDateTime callAnnounce(long millisToAdd) {
+            var now = ZonedDateTime.now();
+            timekeeper.announce(now.plus(millisToAdd, ChronoUnit.MILLIS));
+            return now;
+        }
+    }
+
     static class Timekeeper {
 
         String announce(Instant anInstant) {
             return "The time is now " + anInstant.toString();
+        }
+
+        String announce(ZonedDateTime zonedDateTime) {
+            return "The time is now " + zonedDateTime.toString();
         }
     }
 }


### PR DESCRIPTION
Add three new overloads of isNear in JavaTimeArgumentMatchers that
accept ZonedDateTime instead of Instant.

There is probably a way to make the code contain less duplication, e.g.
by using the common Temporal supertype of Instant and ZonedDateTime.
But for now, this first implementation leaves the existing Instant-based
methods alone.

So, both the production code and the tests are almost identical
except for the type, ZonedDateTime vs. Instant. Again, not ideal, but
for now it is the "safer" choice for methods that I don't expect to
change much, if ever, from now on, since the existing production methods
are the same.

In the future, we could revisit refactoring this code if, for example,
we need to add more overloads that accept additional temporal types such
as LocalDateTime, OffsetDateTime, and so on.

Closes #282