### PR TITLE
Add runtime dependency requirements to H2 extension

### DIFF
--- a/src/main/java/org/kiwiproject/test/h2/H2DatabaseTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/h2/H2DatabaseTestHelper.java
@@ -14,6 +14,9 @@ import java.sql.SQLException;
 
 /**
  * Utilities for H2 databases.
+ * <p>
+ * This requires <a href="https://mvnrepository.com/artifact/com.h2database/h2">h2</a> to be
+ * available at runtime when tests are executing.
  */
 @UtilityClass
 @Slf4j

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -56,6 +56,10 @@ import org.kiwiproject.test.h2.H2FileBasedDatabase;
  * When using this extension via {@code @RegisterExtension}, you can use the getter methods to retrieve the entire
  * {@link H2FileBasedDatabase} object or its individual properties. When using it with {@code @ExtendWith} and an
  * injected parameter, you obviously have direct access to the {@link H2FileBasedDatabase} object.
+ * <p>
+ * This requires <a href="https://mvnrepository.com/artifact/com.h2database/h2">h2</a> and
+ * <a href="https://mvnrepository.com/artifact/commons-io/commons-io">commons-io</a> to be
+ * available at runtime when tests are executing.
  */
 @Slf4j
 public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {


### PR DESCRIPTION
Adds information about the required runtime dependencies
needed by H2FileBasedDatabaseExtension and H2DatabaseTestHelper.