### PR TITLE
Handle nested test classes in H2FileBasedDatabaseExtension

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -96,7 +96,7 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
     }
 
     /**
-     * Deletes the H2 file-based database if the test class is not annotated with {@link Nested}.
+     * Deletes the H2 file-based database unless exiting a nested test class.
      *
      * @param context extension context
      * @throws Exception if the database directory could not be deleted

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -76,8 +76,7 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
     private H2FileBasedDatabase database;
 
     /**
-     * Creates a new H2 file-based database if a database does not exist and the test class is not
-     * annotated with {@link Nested}.
+     * Creates a new H2 file-based database if a database does not exist.
      *
      * @param context extension context
      */

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.test.junit.jupiter;
 
-import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static org.kiwiproject.test.junit.jupiter.JupiterHelpers.isTestClassNested;
 import static org.kiwiproject.test.junit.jupiter.JupiterHelpers.testClassNameOrNull;
 
@@ -83,20 +83,17 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
      */
     @Override
     public void beforeAll(ExtensionContext context) {
-        if (isNull(database)) {
-            LOG.trace("Database does not exist; create it");
-            database = H2DatabaseTestHelper.buildH2FileBasedDatabase();
-            LOG.trace("Created database: {}", database);
-        } else if (isTestClassNested(context)) {
-            LOG.trace("A database already exists and we are inside @Nested test class {}, so not doing anything.",
-                    testClassNameOrNull(context));
-        } else {
-            LOG.warn("database is not null and we are not in a nested class." +
-                    " Not sure what to do, so doing nothing! This could be a bug. Please report it.");
+        if (nonNull(database)) {
+            LOG.trace("A database already exists (we are probably inside a @Nested test class) so not doing anything");
+            return;
         }
+
+        LOG.trace("Database does not exist; create it");
+        database = H2DatabaseTestHelper.buildH2FileBasedDatabase();
 
         var namespace = createNamespace();
         context.getStore(namespace).put(DATABASE_KEY, database);
+        LOG.trace("Created and stored database: {}", database);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/JupiterHelpers.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/JupiterHelpers.java
@@ -2,16 +2,15 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static java.util.Objects.nonNull;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Static utilities related to JUnit Jupiter.
  * <p>
- * Currently this is only for internal usage only.
+ * Currently, this is only for internal usage only.
  */
 @UtilityClass
 @Slf4j
@@ -22,7 +21,7 @@ class JupiterHelpers {
      * annotated with {@link Nested}.
      * <p>
      * If there is no test class, tries a fallback mechanism which inspects
-     * the unique ID of the context to see if if contains "nested-class". This
+     * the unique ID of the context to see if it contains "nested-class". This
      * fallback is admittedly brittle since it relies on the value of a constant
      * in an internal JUnit API (NestedClassTestDescriptor.SEGMENT_TYPE) which is
      * not exported from its module definition.

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/JupiterHelpers.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/JupiterHelpers.java
@@ -1,0 +1,61 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static java.util.Objects.nonNull;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Static utilities related to JUnit Jupiter.
+ * <p>
+ * Currently this is only for internal usage only.
+ */
+@UtilityClass
+@Slf4j
+class JupiterHelpers {
+
+    /**
+     * Check if the class associated with the current test or container is
+     * annotated with {@link Nested}.
+     * <p>
+     * If there is no test class, tries a fallback mechanism which inspects
+     * the unique ID of the context to see if if contains "nested-class". This
+     * fallback is admittedly brittle since it relies on the value of a constant
+     * in an internal JUnit API (NestedClassTestDescriptor.SEGMENT_TYPE) which is
+     * not exported from its module definition.
+     *
+     * @param context the extension context
+     * @return true if the context has a test class and is annotated with {@link Nested};
+     * false if there is no test class associated with the context, or if the context
+     * unique ID does not contain "nested-class"
+     * @implNote The fallback mechanism is brittle and relies on internal JUnit
+     * implementation details which are subject to change and therefore make the
+     * fallback return false even in cases where it should be true.
+     */
+    static boolean isTestClassNested(ExtensionContext context) {
+        var testClass = context.getTestClass().orElse(null);
+        if (nonNull(testClass)) {
+            return testClass.isAnnotationPresent(Nested.class);
+        }
+
+        LOG.warn("No test class exists for context {} ;" +
+                " trying 'nested-class' fallback to determine if we're in a @Nested test class",
+                context.getUniqueId());
+
+        return context.getUniqueId().contains("nested-class");
+    }
+
+    /**
+     * Returns the name of the class associated with the current test or container, or
+     * null if one does not exist.
+     *
+     * @param context the extension context
+     * @return the test class name
+     */
+    static String testClassNameOrNull(ExtensionContext context) {
+        return context.getTestClass().map(Class::getName).orElse(null);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +20,23 @@ import java.sql.SQLException;
 class H2FileBasedDatabaseExtensionExtendWithTest {
 
     private H2FileBasedDatabase databaseFromSetup;
+
+    // This exists so that we can test custom database setup
+    @BeforeAll
+    static void beforeAll(@H2Database H2FileBasedDatabase database) {
+        try (var conn = database.getDataSource().getConnection()) {
+            var createTableStmt = conn.createStatement();
+            createTableStmt.execute("create table people (name varchar , age integer)");
+
+            var insertDataStmt = conn.createStatement();
+            insertDataStmt.addBatch("insert into people values ('Bob', 42)");
+            insertDataStmt.addBatch("insert into people values ('Alice', 24)");
+            insertDataStmt.addBatch("insert into people values ('Zack', 12)");
+            insertDataStmt.executeBatch();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @BeforeEach
     void setUp(@H2Database H2FileBasedDatabase database) {
@@ -49,6 +67,17 @@ class H2FileBasedDatabaseExtensionExtendWithTest {
         }
     }
 
+    @Test
+    void shouldHaveCreatedPeopleTableInCustomBeforeAll(@H2Database H2FileBasedDatabase database) throws SQLException {
+        try (var conn = database.getDataSource().getConnection();
+             var stmt = conn.createStatement();
+             var rs = stmt.executeQuery("select count(*) as count from people")) {
+
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt("count")).isEqualTo(3);
+        }
+    }
+
     @Nested
     class NestedTestClass {
 
@@ -74,6 +103,25 @@ class H2FileBasedDatabaseExtensionExtendWithTest {
         @Test
         void shouldHaveSameDatabaseForNestedAndParentSetup() {
             assertThat(databaseFromNestedSetup).isSameAs(databaseFromSetup);
+        }
+    }
+
+    @DisplayName("Another Nested Test Class")
+    @Nested
+    class AnotherNestedTestClass {
+
+        @Test
+        void shouldReceiveSameDatabaseAsParent(@H2Database H2FileBasedDatabase database) {
+            assertThat(database).isSameAs(databaseFromSetup);
+        }
+
+        @Nested
+        class NestedInsideAnotherNestedTestClass {
+
+            @Test
+            void shouldReceiveSameDatabaseAsParent(@H2Database H2FileBasedDatabase database) {
+                assertThat(database).isSameAs(databaseFromSetup);
+            }
         }
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
@@ -22,6 +22,7 @@ class H2FileBasedDatabaseExtensionExtendWithTest {
     private H2FileBasedDatabase databaseFromSetup;
 
     // This exists so that we can test custom database setup
+    @SuppressWarnings({"SqlNoDataSourceInspection", "SqlDialectInspection"})
     @BeforeAll
     static void beforeAll(@H2Database H2FileBasedDatabase database) {
         try (var conn = database.getDataSource().getConnection()) {

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
@@ -2,7 +2,10 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.test.h2.H2FileBasedDatabase;
@@ -21,6 +24,30 @@ class H2FileBasedDatabaseExtensionRegisterTest {
     @RegisterExtension
     final H2DatabaseTestExtension testExtension = new H2DatabaseTestExtension(DATABASE_EXTENSION.getDatabase());
 
+    private H2FileBasedDatabase databaseFromSetup;
+
+    // This exists so that we can test custom database setup
+    @BeforeAll
+    static void beforeAll(@H2Database H2FileBasedDatabase database) {
+        try (var conn = database.getDataSource().getConnection()) {
+            var createTableStmt = conn.createStatement();
+            createTableStmt.execute("create table people (name varchar , age integer)");
+
+            var insertDataStmt = conn.createStatement();
+            insertDataStmt.addBatch("insert into people values ('Bob', 42)");
+            insertDataStmt.addBatch("insert into people values ('Alice', 24)");
+            insertDataStmt.addBatch("insert into people values ('Zack', 12)");
+            insertDataStmt.executeBatch();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeEach
+    void setUp(@H2Database H2FileBasedDatabase database) {
+        this.databaseFromSetup = database;
+    }
+
     @Test
     void shouldMakeDatabaseAvailableToTests() {
         assertThat(DATABASE_EXTENSION.getDatabase()).isNotNull();
@@ -34,6 +61,11 @@ class H2FileBasedDatabaseExtensionRegisterTest {
         assertThat(testExtension.getDatabase()).isSameAs(DATABASE_EXTENSION.getDatabase());
     }
 
+    @Test
+    void shouldProvideDatabaseInTestMethod(@H2Database H2FileBasedDatabase database) {
+        assertThat(database).isNotNull();
+    }
+
     @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
     @Test
     void shouldBeAbleToConnectToDatabase(@H2Database H2FileBasedDatabase database) throws SQLException {
@@ -43,6 +75,64 @@ class H2FileBasedDatabaseExtensionRegisterTest {
 
             assertThat(rs.next()).isTrue();
             assertThat(rs.getInt("count")).isZero();
+        }
+    }
+
+    @Test
+    void shouldHaveCreatedPeopleTableInCustomBeforeAll(@H2Database H2FileBasedDatabase database) throws SQLException {
+        try (var conn = database.getDataSource().getConnection();
+             var stmt = conn.createStatement();
+             var rs = stmt.executeQuery("select count(*) as count from people")) {
+
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt("count")).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    class NestedTestClass {
+
+        private H2FileBasedDatabase databaseFromNestedSetup;
+
+        @BeforeEach
+        void setUp(@H2Database H2FileBasedDatabase database) {
+            this.databaseFromNestedSetup = database;
+        }
+
+        @Test
+        void shouldProvideDatabaseInNestedTestMethod(@H2Database H2FileBasedDatabase database) {
+            assertThat(database).isNotNull();
+        }
+
+        @Test
+        void shouldProvideDatabaseInNestedClassLifecycleMethod(@H2Database H2FileBasedDatabase database) {
+            assertThat(databaseFromNestedSetup)
+                    .isNotNull()
+                    .isSameAs(database);
+        }
+
+        @Test
+        void shouldHaveSameDatabaseForNestedAndParentSetup() {
+            assertThat(databaseFromNestedSetup).isSameAs(databaseFromSetup);
+        }
+    }
+
+    @DisplayName("Another Nested Test Class")
+    @Nested
+    class AnotherNestedTestClass {
+
+        @Test
+        void shouldReceiveSameDatabaseAsParent(@H2Database H2FileBasedDatabase database) {
+            assertThat(database).isSameAs(databaseFromSetup);
+        }
+
+        @Nested
+        class NestedInsideAnotherNestedTestClass {
+
+            @Test
+            void shouldReceiveSameDatabaseAsParent(@H2Database H2FileBasedDatabase database) {
+                assertThat(database).isSameAs(databaseFromSetup);
+            }
         }
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
@@ -27,6 +27,7 @@ class H2FileBasedDatabaseExtensionRegisterTest {
     private H2FileBasedDatabase databaseFromSetup;
 
     // This exists so that we can test custom database setup
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
     @BeforeAll
     static void beforeAll(@H2Database H2FileBasedDatabase database) {
         try (var conn = database.getDataSource().getConnection()) {

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/JupiterHelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/JupiterHelpersTest.java
@@ -1,0 +1,60 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Optional;
+
+@DisplayName("JupiterHelpers")
+class JupiterHelpersTest {
+
+    @Nested
+    class IsTestClassNested {
+
+        private ExtensionContext context;
+
+        @BeforeEach
+        void setUp() {
+            context = mock(ExtensionContext.class);
+        }
+
+        @Test
+        void shouldReturnFalse_WhenTestClassNotAnnotatedWithNested() {
+            when(context.getTestClass()).thenReturn(Optional.of(JupiterHelpersTest.class));
+
+            assertThat(JupiterHelpers.isTestClassNested(context)).isFalse();
+        }
+
+        @Test
+        void shouldReturnTrue_WhenTestClassIsAnnotatedWithNested() {
+            when(context.getTestClass()).thenReturn(Optional.of(IsTestClassNested.class));
+
+            assertThat(JupiterHelpers.isTestClassNested(context)).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_WhenTestClassIsNotPresent_AndNestedClass_IsInUniqueId() {
+            when(context.getTestClass()).thenReturn(Optional.empty());
+            when(context.getUniqueId()).thenReturn(
+                    "[engine:junit-jupiter]/[class:org.kiwiproject.test.junit.jupiter.SampleTest]/[nested-class:SampleNestedTest]");
+
+            assertThat(JupiterHelpers.isTestClassNested(context)).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_WhenTestClassIsNotPresent_AndNestedClass_NotInUniqueId() {
+            when(context.getTestClass()).thenReturn(Optional.empty());
+            when(context.getUniqueId()).thenReturn(
+                    "[engine:junit-jupiter]/[class:org.kiwiproject.test.junit.jupiter.SampleTest]");
+
+            assertThat(JupiterHelpers.isTestClassNested(context)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
* Change H2FileBasedDatabaseExtension#beforeAll so that it only creates
   the test database at the top-level, i.e. not when it encounters
   a nested test class.
* Similarly, update  H2FileBasedDatabaseExtension#beforeAll to only
  delete the test database at the top-level

Fixes #333