### PR TITLE
Use pure Java to delete H2 database directory; remove commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>kiwi</artifactId>
             <version>${kiwi.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -69,12 +69,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -216,9 +210,9 @@
             <artifactId>mongo-java-server</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- test dependencies -->
-        
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -5,6 +5,8 @@ import static java.util.Objects.nonNull;
 import static org.kiwiproject.test.junit.jupiter.JupiterHelpers.isTestClassNested;
 import static org.kiwiproject.test.junit.jupiter.JupiterHelpers.testClassNameOrNull;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import lombok.Getter;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
@@ -123,7 +125,8 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
         }
     }
 
-    private static void deleteOrThrowUnchecked(Path p) {
+    @VisibleForTesting
+    static void deleteOrThrowUnchecked(Path p) {
         try {
             Files.delete(p);
         } catch (IOException e) {

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionUtilitiesTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionUtilitiesTest.java
@@ -1,0 +1,29 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.UncheckedIOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+@DisplayName("H2FileBasedDatabaseExtension static utility tests")
+class H2FileBasedDatabaseExtensionUtilitiesTest {
+
+    @Nested
+    class DeleteOrThrowUnchecked {
+
+        // Make Sonar happy and cover the catch block
+        @Test
+        void shouldThrowUncheckedIOExeption_WhenPathIsNotValid() {
+            var p = Path.of("/this/does/not/exist");
+            assertThatThrownBy(() -> H2FileBasedDatabaseExtension.deleteOrThrowUnchecked(p))
+                    .isExactlyInstanceOf(UncheckedIOException.class)
+                    .hasCauseExactlyInstanceOf(NoSuchFileException.class);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionUtilitiesTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionUtilitiesTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.test.junit.jupiter;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
* Replace call to FileUtils.#deleteDirectory from commons-io with
  a pure Java implementation, so that we can remove the dependency
  on commons-io for just this one method
* Remove the commons-io dependency from our POM

Closes #328