### PR TITLE
Make Jdbi extensions more robust to SQL failures

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtension.java
@@ -126,13 +126,16 @@ public class Jdbi3DaoExtension<T> implements BeforeEachCallback, AfterEachCallba
         LOG.trace("Opening handle");
         handle = jdbi.open();
 
-        LOG.trace("Txn isolation level: {}", handle.getTransactionIsolationLevel());
+        LOG.trace("Original autoCommit: {}", Jdbi3Helpers.describeAutoCommit(handle));
 
         LOG.trace("Attach type {} to handle", daoType);
         dao = handle.attach(daoType);
 
         LOG.trace("Beginning transaction");
         handle.begin();
+
+        LOG.trace("Transaction isolation level: {}", Jdbi3Helpers.describeTransactionIsolationLevel(handle));
+        LOG.trace("autoCommit in transaction: {}", Jdbi3Helpers.describeAutoCommit(handle));
 
         LOG.trace("Done setting up for JDBI DAO test");
     }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Extension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Extension.java
@@ -103,10 +103,13 @@ public class Jdbi3Extension implements BeforeEachCallback, AfterEachCallback {
         LOG.trace("Opening handle");
         handle = jdbi.open();
 
-        LOG.trace("Txn isolation level: {}", handle.getTransactionIsolationLevel());
+        LOG.trace("Original autoCommit: {}", Jdbi3Helpers.describeAutoCommit(handle));
 
         LOG.trace("Beginning transaction");
         handle.begin();
+
+        LOG.trace("Transaction isolation level: {}", Jdbi3Helpers.describeTransactionIsolationLevel(handle));
+        LOG.trace("autoCommit in transaction: {}", Jdbi3Helpers.describeAutoCommit(handle));
 
         LOG.trace("Done setting up for JDBI test");
     }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3MultiDaoExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3MultiDaoExtension.java
@@ -128,7 +128,7 @@ public class Jdbi3MultiDaoExtension implements BeforeEachCallback, AfterEachCall
         LOG.trace("Opening handle");
         handle = jdbi.open();
 
-        LOG.trace("Txn isolation level: {}", handle.getTransactionIsolationLevel());
+        LOG.trace("Original autoCommit: {}", Jdbi3Helpers.describeAutoCommit(handle));
 
         LOG.trace("Attach types to handle: {}", daoTypes);
 
@@ -145,6 +145,9 @@ public class Jdbi3MultiDaoExtension implements BeforeEachCallback, AfterEachCall
 
         LOG.trace("Beginning transaction");
         handle.begin();
+
+        LOG.trace("Transaction isolation level: {}", Jdbi3Helpers.describeTransactionIsolationLevel(handle));
+        LOG.trace("autoCommit in transaction: {}", Jdbi3Helpers.describeAutoCommit(handle));
 
         LOG.trace("Done setting up for JDBI DAO test");
     }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3HelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3HelpersTest.java
@@ -1,29 +1,49 @@
 package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.CloseException;
 import org.jdbi.v3.core.ConnectionFactory;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.h2.H2DatabasePlugin;
 import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.core.transaction.TransactionException;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+import org.jdbi.v3.core.transaction.UnableToManipulateTransactionIsolationLevelException;
 import org.jdbi.v3.postgres.PostgresPlugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.h2.H2FileBasedDatabase;
+import org.mockito.stubbing.OngoingStubbing;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 
 @DisplayName("Jdbi3Helpers")
+@Slf4j
 @ExtendWith(H2FileBasedDatabaseExtension.class)
 class Jdbi3HelpersTest {
 
@@ -117,6 +137,39 @@ class Jdbi3HelpersTest {
     }
 
     @Nested
+    class FindDatabasePlugin {
+
+        private Jdbi jdbi;
+
+        @BeforeEach
+        void setUp() {
+            jdbi = mock(Jdbi.class);
+        }
+
+        @Test
+        void shouldReturnPluginWhenFound() {
+            var h2Plugin = new H2DatabasePlugin();
+            whenWithHandleCalled().thenReturn(Optional.of(h2Plugin));
+
+            var pluginOptional = Jdbi3Helpers.findDatabasePlugin(jdbi);
+            assertThat(pluginOptional).contains(h2Plugin);
+        }
+
+        @Test
+        void shouldReturnEmptyWhenExceptionThrownFindingPlugin() {
+            whenWithHandleCalled().thenThrow(new SQLException("oops"));
+
+            var pluginOptional = Jdbi3Helpers.findDatabasePlugin(jdbi);
+            assertThat(pluginOptional).isEmpty();
+        }
+
+        @SuppressWarnings("unchecked")
+        private OngoingStubbing<Object> whenWithHandleCalled() {
+            return when(jdbi.withHandle(any(HandleCallback.class)));
+        }
+    }
+
+    @Nested
     class ConfigureSqlLogger {
 
         private Jdbi jdbi;
@@ -141,6 +194,211 @@ class Jdbi3HelpersTest {
             assertThat(jdbiSqlLogger.getLoggerName()).isEqualTo(loggerName);
 
             verify(jdbi).setSqlLogger(jdbiSqlLogger);
+        }
+    }
+
+    @Nested
+    class DescribeTransactionIsolationLevel {
+
+        private Handle handle;
+
+        @BeforeEach
+        void setUp() {
+            handle = mock(Handle.class);
+        }
+
+        @ParameterizedTest
+        @EnumSource(TransactionIsolationLevel.class)
+        void shouldDescribeWhenSuccessGettingIsolationLevel(TransactionIsolationLevel level) {
+            when(handle.getTransactionIsolationLevel()).thenReturn(level);
+
+            var description = Jdbi3Helpers.describeTransactionIsolationLevel(handle);
+            assertThat(description)
+                    .isEqualTo("%s (java.sql.Connection isolation level: %d)", level.name(), level.intValue());
+        }
+
+        @Test
+        void shouldDescribeWhenExceptionGettingIsolationLevel() {
+            var sqlException = new SQLException("error getting isolation");
+            var jdbiException = new UnableToManipulateTransactionIsolationLevelException(
+                    "unable to access current setting", sqlException);
+            when(handle.getTransactionIsolationLevel()).thenThrow(jdbiException);
+
+            var description = Jdbi3Helpers.describeTransactionIsolationLevel(handle);
+            assertThat(description).isEqualTo("ERROR (%s: %s, cause: %s)",
+                    jdbiException.getClass().getName(), jdbiException.getMessage(), sqlException);
+        }
+    }
+
+    @Nested
+    class GetTransactionIsolationLevel {
+
+        private Handle handle;
+
+        @BeforeEach
+        void setUp() {
+            handle = mock(Handle.class);
+        }
+
+        @ParameterizedTest
+        @EnumSource(TransactionIsolationLevel.class)
+        void shouldReturnIsolationLevel(TransactionIsolationLevel level) {
+            when(handle.getTransactionIsolationLevel()).thenReturn(level);
+
+            var result = Jdbi3Helpers.getTransactionIsolationLevel(handle);
+            assertThat(result.getLeft()).isEqualTo(level);
+            assertThat(result.getRight()).isNull();
+        }
+
+        @Test
+        void shouldReturnException() {
+            var sqlException = new SQLException("error getting isolation");
+            var jdbiException = new UnableToManipulateTransactionIsolationLevelException(
+                    "unable to access current setting", sqlException);
+            when(handle.getTransactionIsolationLevel()).thenThrow(jdbiException);
+
+            var result = Jdbi3Helpers.getTransactionIsolationLevel(handle);
+            assertThat(result.getLeft()).isNull();
+            assertThat(result.getRight()).isSameAs(jdbiException);
+        }
+    }
+
+    @Nested
+    class DescribeAutoCommit {
+
+        private Handle handle;
+        private Connection connection;
+
+        @BeforeEach
+        void setUp() {
+            handle = mock(Handle.class);
+            connection = mock(Connection.class);
+            when(handle.getConnection()).thenReturn(connection);
+        }
+
+        @Test
+        void shouldDescribeWhenSuccessGettingAutoCommitValue() throws SQLException {
+            when(connection.getAutoCommit()).thenReturn(false);
+
+            var description = Jdbi3Helpers.describeAutoCommit(handle);
+            assertThat(description).isEqualTo("false");
+        }
+
+        @Test
+        void shouldDescribeWhenExceptionGettingAutoCommitValue() throws SQLException {
+            var exception = new SQLException("unable to get autoCommit");
+            when(connection.getAutoCommit()).thenThrow(exception);
+
+            var description = Jdbi3Helpers.describeAutoCommit(handle);
+            assertThat(description).isEqualTo("ERROR (%s: %s, cause: %s)",
+                    exception.getClass().getName(), exception.getMessage(), exception.getCause());
+        }
+    }
+
+    @Nested
+    class GetAutoCommit {
+
+        private Handle handle;
+        private Connection connection;
+
+        @BeforeEach
+        void setUp() {
+            handle = mock(Handle.class);
+            connection = mock(Connection.class);
+            when(handle.getConnection()).thenReturn(connection);
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void shouldReturnAutoCommitValue(boolean value) throws SQLException {
+            when(connection.getAutoCommit()).thenReturn(value);
+
+            var result = Jdbi3Helpers.getAutoCommit(handle);
+            assertThat(result.getLeft()).isEqualTo(value);
+            assertThat(result.getRight()).isNull();
+        }
+
+        @Test
+        void shouldReturnException() throws SQLException {
+            var exception = new SQLException("unable to get autoCommit");
+            when(connection.getAutoCommit()).thenThrow(exception);
+
+            var result = Jdbi3Helpers.getAutoCommit(handle);
+            assertThat(result.getLeft()).isNull();
+            assertThat(result.getRight()).isSameAs(exception);
+        }
+    }
+
+    @Nested
+    class RollbackAndClose {
+
+        private Handle handle;
+
+        @BeforeEach
+        void setUp() {
+            handle = mock(Handle.class);
+        }
+
+        @Test
+        void shouldRollbackAndCloseTheHandle() {
+            when(handle.getConnection()).thenReturn(mock(Connection.class));
+
+            Jdbi3Helpers.rollbackAndClose(handle, LOG);
+
+            verify(handle, atLeastOnce()).getConnection();  // for logging autoCommit value
+            verify(handle).rollback();
+            verify(handle).close();
+            verifyNoMoreInteractions(handle);
+        }
+
+        @Test
+        void shouldCatchRollbackFailures() {
+            var cause = new SQLException("Cannot rollback when autoCommit is enabled.");
+            var exception = new TransactionException("Failed to rollback transaction", cause);
+            when(handle.rollback()).thenThrow(exception);
+            when(handle.getConnection()).thenReturn(mock(Connection.class));
+
+            assertThatCode(() -> Jdbi3Helpers.rollbackAndClose(handle, LOG)).doesNotThrowAnyException();
+
+            verify(handle).rollback();
+            verify(handle, atLeastOnce()).getConnection();
+            verify(handle).close();
+            verifyNoMoreInteractions(handle);
+        }
+
+        @Test
+        void shouldCatchCloseFailures() {
+            var cause = new SQLException("Cannot close connection");
+            var exception = new CloseException("Failed to close connection", cause);
+            doThrow(exception).when(handle).close();
+            when(handle.getConnection()).thenReturn(mock(Connection.class));
+
+            assertThatCode(() -> Jdbi3Helpers.rollbackAndClose(handle, LOG)).doesNotThrowAnyException();
+
+            verify(handle).rollback();
+            verify(handle, atLeastOnce()).getConnection();
+            verify(handle).close();
+            verifyNoMoreInteractions(handle);
+        }
+
+        @Test
+        void shouldCatchRollbackAndCloseFailures() {
+            var rollbackExceptionCause = new SQLException("Cannot rollback when autoCommit is enabled.");
+            var rollbackException = new TransactionException("Failed to rollback transaction", rollbackExceptionCause);
+            when(handle.rollback()).thenThrow(rollbackException);
+
+            var closeExceptionCause = new SQLException("Cannot close connection");
+            var closeException = new CloseException("Failed to close connection", closeExceptionCause);
+            doThrow(closeException).when(handle).close();
+
+            when(handle.getConnection()).thenReturn(mock(Connection.class));
+
+            assertThatCode(() -> Jdbi3Helpers.rollbackAndClose(handle, LOG)).doesNotThrowAnyException();
+
+            verify(handle).rollback();
+            verify(handle, atLeast(2)).getConnection();
+            verify(handle).close();
+            verifyNoMoreInteractions(handle);
         }
     }
 

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3MultiDaoExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3MultiDaoExtensionTest.java
@@ -71,6 +71,19 @@ class Jdbi3MultiDaoExtensionTest {
     }
 
     @Test
+    @Order(0)
+    void shouldProvideMetadata() {
+        assertThat(multiDaoExtension.getJdbi()).isNotNull();
+        assertThat(multiDaoExtension.getDaoTypes())
+                .containsExactlyInAnyOrder(PersonDao.class, PlaceDao.class, ThingDao.class);
+        assertThat(multiDaoExtension.getDaos())
+                .hasSize(3)
+                .containsEntry(PersonDao.class, personDao)
+                .containsEntry(PlaceDao.class, placeDao)
+                .containsEntry(ThingDao.class, thingDao);
+    }
+
+    @Test
     @Order(1)
     void shouldBeginTransactionResultingInDisabledAutoCommit() throws SQLException {
         assertThat(handle.getConnection().getAutoCommit()).isFalse();


### PR DESCRIPTION
* Add helper methods to Jdbi3Helpers to get the transaction isolation level and autoCommit value of the underlying Connection. If these calls fail, do not permit that failure to propagate and potentially mask the underlying problem.
* Move the log statement for the transaction isolation level to after we begin the transaction, not before. It makes more sense to get this value after the transaction has begun (though I am not sure if the value actually changes).
* Log the autoCommit value before and after we begin the transaction in the beforeEach method, and before and after we roll back the transaction. This will permit better diagnostics if we see that the rollback fails due to autoCommit being set to true (this happens in Postgres and H2, and probably in other SQL databases.)
* Add miscellaneous explanation in Javadoc of Jdbi3Helpers#DatabaseType why we use the H2DatabasePlugin directly whereas we use a String for the Postgres plugin class name.
* A few minor grammatical fixes in Javadoc of Jdbi3Helpers.
* Add tests for new features and for Jdbi3Helpers#findDatabasePlugin. Made findDatabasePlugin package-private to be accessible from tests.

Closes #346