### PR TITLE
Preemptively fix compilation problems with ServerVersion

### DIFF
--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
@@ -75,12 +75,6 @@ class MongoServerExtensionTest {
     }
 
     @Test
-    void shouldCreateServerExtensionWithMongo3_0() {
-        var extension = new MongoServerExtension(ServerVersion.MONGO_3_0);
-        assertThat(extension.getServerVersion()).isEqualTo(ServerVersion.MONGO_3_0);
-    }
-
-    @Test
     void shouldCreateServerExtensionWithDefaultMongo3_6() {
         var extension = new MongoServerExtension();
         assertThat(extension.getServerVersion()).isEqualTo(ServerVersion.MONGO_3_6);

--- a/src/test/java/org/kiwiproject/test/mongo/MongoServerTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoServerTestsTest.java
@@ -33,8 +33,8 @@ class MongoServerTestsTest {
     }
 
     @Test
-    void shouldStartInMemoryMongoServer_WithServerVersion3() {
-        var server = MongoServerTests.startInMemoryMongoServer(ServerVersion.MONGO_3_0);
+    void shouldStartInMemoryMongoServer_WithServerVersion3_6() {
+        var server = MongoServerTests.startInMemoryMongoServer(ServerVersion.MONGO_3_6);
         assertThat(server).isNotNull();
     }
 


### PR DESCRIPTION
* Remove test in MongoServerExtensionTest that used the ServerVersion.MONGO_3_0 constant, since it was removed from mongo-java-server in version 1.42.0
* Change test in MongoServerTestsTest to use MONGO_3_6, which is the only enum constant now in ServerVersion