### PR TITLE
Fix CodeQL workflow to work with Lombok

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         
     # Show file causing compilation problems before Delombok
     - name: Debugging 1
-      run: cat/home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+      run: cat /home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     # Delombok before the build
     - name: Delombok
@@ -58,7 +58,7 @@ jobs:
 
     # Show file causing compilation problems after Delombok
     - name: Debugging 2
-      run: cat/home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+      run: cat /home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # queries: security-extended,security-and-quality
+        queries: security-extended,security-and-quality
 
     - name: Cache Maven packages
       uses: actions/cache@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,10 @@ jobs:
         
     # Show file causing compilation problems before Delombok
     - name: Debugging 1
-      run: cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+      run: |
+        cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+        echo ${{ github.workspace }}
+        ls ${{ github.workspace }}
 
     # Delombok before the build
     - name: Delombok

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,6 @@ jobs:
         echo ${{ github.repository }}
         echo "github.action_path:"
         echo ${{ github.action_path }}
-        echo "github.action_path:"
         echo ${{ github.workspace }}
         ls ${{ github.workspace }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,11 @@ jobs:
     - name: Debugging 1
       run: |
         cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+        echo "github.repository:"
+        echo ${{ github.repository }}
+        echo "github.action_path:"
+        echo ${{ github.action_path }}
+        echo "github.action_path:"
         echo ${{ github.workspace }}
         ls ${{ github.workspace }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,41 +33,21 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         queries: security-extended,security-and-quality
 
-    # Use cache of Maven repository
     - name: Cache Maven packages
       uses: actions/cache@v3
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-        
-    # Show file causing compilation problems before Delombok
-    - name: Debugging 1
-      run: |
-        cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
-        echo "github.repository:"
-        echo ${{ github.repository }}
-        echo "github.action_path:"
-        echo ${{ github.action_path }}
-        echo "github.workspace:"
-        echo ${{ github.workspace }}
-        echo "ls github.workspace:"
-        ls ${{ github.workspace }}
 
-    # Delombok before the build
     - name: Delombok
       uses: advanced-security/delombok@main
-
-    # Show file causing compilation problems after Delombok
-    - name: Debugging 2
-      run: cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,9 @@ jobs:
         echo ${{ github.repository }}
         echo "github.action_path:"
         echo ${{ github.action_path }}
+        echo "github.workspace:"
         echo ${{ github.workspace }}
+        echo "ls github.workspace:"
         ls ${{ github.workspace }}
 
     # Delombok before the build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        queries: security-extended,security-and-quality
+        # queries: security-extended,security-and-quality
 
     - name: Cache Maven packages
       uses: actions/cache@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,10 +47,18 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+        
+    # Show file causing compilation problems before Delombok
+    - name: Debugging 1
+      run: cat/home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     # Delombok before the build
     - name: Delombok
       uses: advanced-security/delombok@main
+
+    # Show file causing compilation problems after Delombok
+    - name: Debugging 2
+      run: cat/home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -22,7 +11,9 @@ on:
       - '**/*.md'
       - '**/*.txt'
   schedule:
-    - cron: '32 21 * * 3'
+    - cron: '32 21 * * 3'  # At 21:32 on Wednesdays
+  workflow_dispatch:
+    # no inputs needed here
 
 jobs:
   analyze:
@@ -37,10 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'java' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
@@ -51,28 +38,22 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+        queries: security-extended,security-and-quality
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+    # Use cache of Maven repository
+    - name: Cache Maven packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
 
+    # Delombok before the build
+    - name: Delombok
+      uses: advanced-security/delombok@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         
     # Show file causing compilation problems before Delombok
     - name: Debugging 1
-      run: cat /home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+      run: cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     # Delombok before the build
     - name: Delombok
@@ -58,7 +58,7 @@ jobs:
 
     # Show file causing compilation problems after Delombok
     - name: Debugging 2
-      run: cat /home/runner/work/kiwi-test/kiwi-test/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+      run: cat /home/runner/work/kiwi-test/kiwi-test/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/src/main/java/org/kiwiproject/test/junit/ParameterizedTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/junit/ParameterizedTestHelper.java
@@ -123,7 +123,7 @@ public class ParameterizedTestHelper {
      * @param inputValues     the inputs
      * @param expectedResults the expected results
      * @param function        function that accepts a T and produces an R
-     * @param <T>the          input type
+     * @param <T>             the input type
      * @param <R>             the result type
      * @see ParameterizedTests#inputs(Object[])
      * @see ParameterizedTestHelper#expectedResults(Object[])

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -7,7 +7,6 @@ import static org.kiwiproject.test.junit.jupiter.JupiterHelpers.testClassNameOrN
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
-import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -22,6 +21,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import javax.sql.DataSource;
 
 /**
  * JUnit Jupiter extension that creates a file-based H2 database before all tests and deletes it after all tests
@@ -77,7 +78,6 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
     private static final String DATABASE_KEY = "database";
 
     @Getter
-    @Delegate
     private H2FileBasedDatabase database;
 
     /**
@@ -164,5 +164,17 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
 
     private H2FileBasedDatabase getDatabase(ExtensionContext context, ExtensionContext.Namespace namespace) {
         return context.getStore(namespace).get(DATABASE_KEY, H2FileBasedDatabase.class);
+    }
+
+    public File getDirectory() {
+        return this.getDatabase().getDirectory();
+    }
+
+    public String getUrl() {
+        return this.getDatabase().getUrl();
+    }
+
+    public DataSource getDataSource() {
+        return this.getDatabase().getDataSource();
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtension.java
@@ -8,7 +8,6 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import lombok.Getter;
-import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -16,6 +15,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.kiwiproject.test.h2.H2FileBasedDatabase;
+
+import java.io.File;
+
+import javax.sql.DataSource;
 
 /**
  * This JUnit Jupiter extension provides a file-based H2 database and runs Liquibase migrations to allow testing
@@ -84,7 +87,6 @@ public class H2LiquibaseExtension implements BeforeAllCallback, AfterAllCallback
      * The H2 file-based database for use by tests, e.g. to obtain the DataSource.
      */
     @Getter
-    @Delegate
     private H2FileBasedDatabase database;
 
     /**
@@ -158,5 +160,17 @@ public class H2LiquibaseExtension implements BeforeAllCallback, AfterAllCallback
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
         return h2Extension.resolveParameter(parameterContext, extensionContext);
+    }
+
+    public File getDirectory() {
+        return this.getDatabase().getDirectory();
+    }
+
+    public String getUrl() {
+        return this.getDatabase().getUrl();
+    }
+
+    public DataSource getDataSource() {
+        return this.getDatabase().getDataSource();
     }
 }

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -301,12 +301,16 @@ public class MongoTestProperties {
      *
      * @param databaseName the database name
      * @return the timestamp
-     * @throws IllegalArgumentException if the databaseName is blank or does not have any underscores
-     * @throws NumberFormatException    if the extracted "timestamp" cannot be parsed into a {@code long}
+     * @throws IllegalArgumentException if the databaseName is blank, does not contain any underscores, or if the
+     * extracted timestamp cannot be parsed into a {@code long}
      */
     public static long extractDatabaseTimestamp(String databaseName) {
         var lastUnderscoreIndex = getLastUnderscoreIndex(databaseName);
-        return Long.parseLong(databaseName.substring(lastUnderscoreIndex + 1));
+        try {
+            return Long.parseLong(databaseName.substring(lastUnderscoreIndex + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("databaseName does not have a numeric timestamp");
+        }
     }
 
     private static int getLastUnderscoreIndex(String databaseName) {

--- a/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoTestProperties.java
@@ -309,7 +309,7 @@ public class MongoTestProperties {
         try {
             return Long.parseLong(databaseName.substring(lastUnderscoreIndex + 1));
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("databaseName does not have a numeric timestamp");
+            throw new IllegalArgumentException("databaseName does not have a numeric timestamp", e);
         }
     }
 

--- a/src/test/java/org/kiwiproject/test/jdbc/RuntimeSQLExceptionTest.java
+++ b/src/test/java/org/kiwiproject/test/jdbc/RuntimeSQLExceptionTest.java
@@ -2,10 +2,12 @@ package org.kiwiproject.test.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
+@DisplayName("RuntimeSQLException")
 class RuntimeSQLExceptionTest {
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionExtendWithTest.java
@@ -25,11 +25,12 @@ class H2FileBasedDatabaseExtensionExtendWithTest {
     @SuppressWarnings({"SqlNoDataSourceInspection", "SqlDialectInspection"})
     @BeforeAll
     static void beforeAll(@H2Database H2FileBasedDatabase database) {
-        try (var conn = database.getDataSource().getConnection()) {
-            var createTableStmt = conn.createStatement();
+        try (var conn = database.getDataSource().getConnection();
+             var createTableStmt = conn.createStatement();
+             var insertDataStmt = conn.createStatement()) {
+
             createTableStmt.execute("create table people (name varchar , age integer)");
 
-            var insertDataStmt = conn.createStatement();
             insertDataStmt.addBatch("insert into people values ('Bob', 42)");
             insertDataStmt.addBatch("insert into people values ('Alice', 24)");
             insertDataStmt.addBatch("insert into people values ('Zack', 12)");

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtensionRegisterTest.java
@@ -30,11 +30,12 @@ class H2FileBasedDatabaseExtensionRegisterTest {
     @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
     @BeforeAll
     static void beforeAll(@H2Database H2FileBasedDatabase database) {
-        try (var conn = database.getDataSource().getConnection()) {
-            var createTableStmt = conn.createStatement();
+        try (var conn = database.getDataSource().getConnection();
+             var createTableStmt = conn.createStatement();
+             var insertDataStmt = conn.createStatement()) {
+
             createTableStmt.execute("create table people (name varchar , age integer)");
 
-            var insertDataStmt = conn.createStatement();
             insertDataStmt.addBatch("insert into people values ('Bob', 42)");
             insertDataStmt.addBatch("insert into people values ('Alice', 24)");
             insertDataStmt.addBatch("insert into people values ('Zack', 12)");

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtensionTest.java
@@ -37,11 +37,11 @@ class H2LiquibaseExtensionTest {
     }
 
     @Test
-    void shouldProvideH2FileBasedDatabase() {
-        var database = H2_LIQUIBASE_EXTENSION.getDatabase();
-        assertThat(database.getUrl()).startsWith("jdbc:h2:");
-        assertThat(database.getDataSource()).isNotNull();
-        assertThat(database.getDirectory()).isDirectory();
+    void shouldMakeDatabaseAvailableToTests() {
+        assertThat(H2_LIQUIBASE_EXTENSION.getDatabase()).isNotNull();
+        assertThat(H2_LIQUIBASE_EXTENSION.getUrl()).isNotBlank();
+        assertThat(H2_LIQUIBASE_EXTENSION.getDirectory()).isNotNull();
+        assertThat(H2_LIQUIBASE_EXTENSION.getDataSource()).isNotNull();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
@@ -436,13 +436,15 @@ class MongoTestPropertiesTest {
         @ArgumentsSource(BlankStringArgumentsProvider.class)
         void shouldThrow_GivenBlankArgument(String blankValue) {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp(blankValue));
+                    .isThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp(blankValue))
+                    .withMessage("databaseName cannot be blank");
         }
 
         @Test
         void shouldThrow_GivenDatabaseNameEndingWithUnderscore() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp("test-service_unit_test_host1_"));
+                    .isThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp("test-service_unit_test_host1_"))
+                    .withMessage("databaseName cannot end with an underscore");
         }
 
         @ParameterizedTest
@@ -453,7 +455,20 @@ class MongoTestPropertiesTest {
         })
         void shouldThrow_GivenNonNumericTimestamp(String databaseName) {
             assertThatThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp(databaseName))
-                    .isExactlyInstanceOf(NumberFormatException.class);
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("databaseName does not have a numeric timestamp");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "test-service-unit-test-host1-foo",
+                "test-service-unit-test-host1-1602375491864",
+                "test-service"
+        })
+        void shouldThrow_GivenInvalidFormatForName(String databaseName) {
+            assertThatThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp(databaseName))
+                    .isExactlyInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("databaseName does not have correct format");
         }
 
         @ParameterizedTest

--- a/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
+++ b/src/test/java/org/kiwiproject/test/mongo/MongoTestPropertiesTest.java
@@ -456,7 +456,8 @@ class MongoTestPropertiesTest {
         void shouldThrow_GivenNonNumericTimestamp(String databaseName) {
             assertThatThrownBy(() -> MongoTestProperties.extractDatabaseTimestamp(databaseName))
                     .isExactlyInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("databaseName does not have a numeric timestamp");
+                    .hasMessage("databaseName does not have a numeric timestamp")
+                    .hasCauseExactlyInstanceOf(NumberFormatException.class);
         }
 
         @ParameterizedTest


### PR DESCRIPTION
Updates to the CodeQL workflow (codeql.yml):
* Fix CodeQL + Lokbok by adding delombok
* Remove extraneous comments
* Cache maven artifacts
* Allow manual triggering (workflow_dispatch)

Additional changes were needed to make CodeQL analysis run without errors.
Specifically, replaced Lombok Delegate annotations in H2FileBasedDatabaseExtension
and H2LiquibaseExtension with "real" methods that perform the delegate the
"old fashioned" way. Otherwise the de-lomboked code did not compile because
the methods that should have been created by the Delegate annotation were not
in the (de-lomboked) source files. I am not sure whether this is something to
do with the way the advanced-security/delombok action works or some other reason.
In any case, since the Delegate annotation is experimental in Lombok, and its description=
web page says it has a "negative" status and it will not move out of experimental status
"anytime soon" and also that "support for this feature may be dropped if future versions
of javac or ecj make it difficult to continue to maintain the feature". So, the safe thing to
do is just write the (simple) code that it produced, so that the CodeQL workflow can
run without failing.

Additional fixes caught by CodeQL:
* Fix erroneous Javadoc in ParameterizedTestHelper
* Fix "potential database resource leak" in H2FileBasedDatabaseExtensionRegisterTest
  and H2FileBasedDatabaseExtensionExtendWithTest
* Catch NumberFormatException in MongoTestProperties#extractDatabaseTimestamp
  and re-throw as an IllegalArgumentException.

The above "additional fixes" were captured as issue #366.

Last, dismissed a whole bunch of false positive CodeQL warnings and notes. These were
all caused (I am about 99.99999% sure anyway) due to Lombok-generated code. Not that
the Lombok code is wrong, rather I think in some cases CodeQL doesn't understand Lombok
while in other cases CodeQL was just wrong. For example, CodeQL does not understand that
a Lombok Singular annotation on a List field ensures it won't be null. It also said there was
a boxed primitive comparison on an int field, which was inside a class annotated with Lombok's
Value annotation.

Closes #366 