### PR TITLE
JaxrsExceptionTestHelper#assertContainsError should report actual errors

### DIFF
--- a/src/main/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelper.java
@@ -119,14 +119,14 @@ public class JaxrsExceptionTestHelper {
     public static ErrorMessage assertContainsError(Response response, int statusCode, String substring) {
         var jaxrsException = toJaxrsException(response);
 
-        return jaxrsException.getErrors()
-                .stream()
+        var errors = jaxrsException.getErrors();
+        return errors.stream()
                 .filter(error -> matchesArguments(error, statusCode, substring))
                 .findFirst()
                 .orElseThrow(() -> {
                     var assertErrorMessage =
-                            f("Response does not contain an ErrorMessage having status {} and message containing: {}",
-                                    statusCode, substring);
+                            f("Response does not contain an ErrorMessage having status {} and message containing: '{}'. Actual errors: {}",
+                                    statusCode, substring, errors);
                     return new AssertionError(assertErrorMessage);
                 });
     }

--- a/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
@@ -267,8 +267,8 @@ class JaxrsExceptionTestHelperTest {
             assertThatThrownBy(() ->
                     JaxrsExceptionTestHelper.assertContainsError(response, statusCode, substring))
                     .isInstanceOf(AssertionError.class)
-                    .hasMessage("Response does not contain an ErrorMessage having status %d and message containing: %s",
-                            statusCode, substring);
+                    .hasMessage("Response does not contain an ErrorMessage having status %d and message containing: '%s'. Actual errors: %s",
+                            statusCode, substring, jaxrsException.getErrors());
         }
     }
 }


### PR DESCRIPTION
* Change the error message reported by assertContainsError so that it reports the expected ErrorMessage and also all the actual errors. This will allow users to determine the problem by having the actual errors for inspection.

Closes #376