### PR TITLE
Add a migration for PostgresAppTestExtension tests

### DIFF
--- a/src/test/resources/H2LiquibaseExtensionTest/test-migrations.xml
+++ b/src/test/resources/H2LiquibaseExtensionTest/test-migrations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
 
     <changeSet id="0001_create_sample_table" author="bob">
         <createTable tableName="sample_table">

--- a/src/test/resources/PostgresAppTestExtensionTest/test-migrations.xml
+++ b/src/test/resources/PostgresAppTestExtensionTest/test-migrations.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
+
+    <changeSet id="0001_create_users_table" author="diane">
+        <createTable tableName="users">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="username" type="text">
+                <constraints nullable="false"/>
+            </column>
+            <column name="password" type="text">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/PostgresLiquibaseTestExtensionTest/test-migrations.xml
+++ b/src/test/resources/PostgresLiquibaseTestExtensionTest/test-migrations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
 
     <changeSet id="0001_create_sample_table" author="bob">
         <createTable tableName="sample_table">


### PR DESCRIPTION
* Add migration to PostgresAppTestExtensionTest/test-migrations.xml to force liquibase to always run migrations (and not think the database is up-to-date)
* Update the Liquibase schema from 3.1 to 4.22 in all test migrations

Fixes #400