### PR TITLE
Return ConstraintViolation objects from validation test helpers

### DIFF
--- a/src/main/java/org/kiwiproject/test/validation/SoftValidationTestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/validation/SoftValidationTestAssertions.java
@@ -2,8 +2,12 @@ package org.kiwiproject.test.validation;
 
 import org.assertj.core.api.SoftAssertions;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.util.Arrays;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
 
 /**
  * A helper class with methods for making AssertJ {@link SoftAssertions} when validating objects using the
@@ -43,95 +47,130 @@ public class SoftValidationTestAssertions {
 
     /**
      * Softly asserts that there are <strong>no</strong> constraint violations.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param object the object to validate
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      * @see ValidationTestHelper#assertNoViolations(SoftAssertions, Validator, Object, Class...)
      */
-    public void assertNoViolations(Object object) {
-        ValidationTestHelper.assertNoViolations(softly, validator, object);
+    public <T> Set<ConstraintViolation<T>> assertNoViolations(T object) {
+        return ValidationTestHelper.assertNoViolations(softly, validator, object);
     }
 
     /**
      * Softly asserts that there are exactly {@code numExpectedViolations} constraint violations on the given object.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param object                the object to validate
      * @param numExpectedViolations the number of violations that are expected
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      * @see ValidationTestHelper#assertViolations(SoftAssertions, Validator, Object, int, Class...)
      */
-    public void assertViolations(Object object, int numExpectedViolations) {
-        ValidationTestHelper.assertViolations(softly, validator, object, numExpectedViolations);
+    public <T> Set<ConstraintViolation<T>> assertViolations(T object, int numExpectedViolations) {
+        return ValidationTestHelper.assertViolations(softly, validator, object, numExpectedViolations);
     }
 
     /**
      * Softly asserts that there is exactly one constraint violation on the given object for the given
      * {@code propertyName}.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values. This is also the reason it returns a
+     * set instead of just a single object.
      *
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      * @see ValidationTestHelper#assertOnePropertyViolation(SoftAssertions, Validator, Object, String, Class...)
      */
-    public void assertOnePropertyViolation(Object object, String propertyName) {
-        ValidationTestHelper.assertOnePropertyViolation(softly, validator, object, propertyName);
+    public <T> Set<ConstraintViolation<T>> assertOnePropertyViolation(T object, String propertyName) {
+        return ValidationTestHelper.assertOnePropertyViolation(softly, validator, object, propertyName);
     }
 
     /**
      * Softly asserts that each of the specified properties has exactly one constraint violation on the given
      * object.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param object        the object to validate
      * @param propertyNames the names of the properties to validate on the given object
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public void assertPropertiesEachHaveOneViolation(Object object, String... propertyNames) {
-        Arrays.stream(propertyNames)
-                .forEach(propertyName -> assertOnePropertyViolation(object, propertyName));
+    public <T> Set<ConstraintViolation<T>> assertPropertiesEachHaveOneViolation(T object, String... propertyNames) {
+        return Arrays.stream(propertyNames)
+                .flatMap(propertyName -> assertOnePropertyViolation(object, propertyName).stream())
+                .collect(toSet());
     }
 
     /**
      * Softly asserts that there are <strong>no</strong> constraint violations on the given object for the
      * given {@code propertyName}.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      * @see ValidationTestHelper#assertNoPropertyViolations(SoftAssertions, Validator, Object, String, Class...)
      */
-    public void assertNoPropertyViolations(Object object, String propertyName) {
-        ValidationTestHelper.assertNoPropertyViolations(softly, validator, object, propertyName);
+    public <T> Set<ConstraintViolation<T>> assertNoPropertyViolations(T object, String propertyName) {
+        return ValidationTestHelper.assertNoPropertyViolations(softly, validator, object, propertyName);
     }
 
     /**
      * Softly assert that each of the specified properties has no constraint violations on the given object.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param object        the object to validate
      * @param propertyNames the names of the properties to validate on the given object
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public void assertPropertiesEachHaveNoViolations(Object object, String... propertyNames) {
-        Arrays.stream(propertyNames)
-                .forEach(propertyName -> assertNoPropertyViolations(object, propertyName));
+    public <T> Set<ConstraintViolation<T>> assertPropertiesEachHaveNoViolations(T object, String... propertyNames) {
+        return Arrays.stream(propertyNames)
+                .flatMap(propertyName -> assertNoPropertyViolations(object, propertyName).stream())
+                .collect(toSet());
     }
 
     /**
      * Softly asserts that there are exactly {@code numExpectedViolations} constraint violations on the given object
      * for the given {@code propertyName}.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param object                the object to validate
      * @param propertyName          the name of the property to validate on the given object
      * @param numExpectedViolations the number of violations that are expected
+     * @return the set of {@link ConstraintViolation} objects
      * @see ValidationTestHelper#assertPropertyViolations(SoftAssertions, Validator, Object, String, int, Class...)
      */
-    public void assertPropertyViolations(Object object, String propertyName, int numExpectedViolations) {
-        ValidationTestHelper.assertPropertyViolations(softly, validator, object, propertyName, numExpectedViolations);
+    public <T> Set<ConstraintViolation<T>> assertPropertyViolations(T object, String propertyName, int numExpectedViolations) {
+        return ValidationTestHelper.assertPropertyViolations(softly, validator, object, propertyName, numExpectedViolations);
     }
 
     /**
      * Softly asserts that the constraint violations match {@code expectedMessages} on the given
      * object for the given {@code propertyName}.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param object           the object to validate
      * @param propertyName     the name of the property to validate on the given object
      * @param expectedMessages the exact validation messages that are expected
+     * @return the set of {@link ConstraintViolation} objects
      * @see ValidationTestHelper#assertPropertyViolations(SoftAssertions, Validator, Object, String, String...)
      */
-    public void assertPropertyViolations(Object object, String propertyName, String... expectedMessages) {
-        ValidationTestHelper.assertPropertyViolations(softly, validator, object, propertyName, expectedMessages);
+    public <T> Set<ConstraintViolation<T>> assertPropertyViolations(T object, String propertyName, String... expectedMessages) {
+        return ValidationTestHelper.assertPropertyViolations(softly, validator, object, propertyName, expectedMessages);
     }
 }

--- a/src/main/java/org/kiwiproject/test/validation/ValidationTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/validation/ValidationTestHelper.java
@@ -1,10 +1,5 @@
 package org.kiwiproject.test.validation;
 
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.kiwiproject.collect.KiwiLists.isNotNullOrEmpty;
-
 import lombok.experimental.UtilityClass;
 import org.assertj.core.api.SoftAssertions;
 import org.kiwiproject.base.KiwiStrings;
@@ -15,6 +10,11 @@ import javax.validation.Validator;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.kiwiproject.collect.KiwiLists.isNotNullOrEmpty;
 
 /**
  * Provides helper methods for making assertions on validation of objects using the Bean Validation API.
@@ -45,6 +45,7 @@ public class ValidationTestHelper {
      * @return a new {@link Validator} instance
      */
     public static Validator newValidator() {
+        // noinspection resource
         return Validation.buildDefaultValidatorFactory().getValidator();
     }
 
@@ -75,30 +76,39 @@ public class ValidationTestHelper {
     /**
      * Performs an AssertJ soft assertion that there are <strong>no</strong> constraint violations on the given
      * object using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param softly an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object the object to validate
      * @param groups the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertNoViolations(SoftAssertions softly, Object object, Class<?>... groups) {
-        assertNoViolations(softly, VALIDATOR, object, groups);
+    public static <T> Set<ConstraintViolation<T>> assertNoViolations(SoftAssertions softly, T object, Class<?>... groups) {
+        return assertNoViolations(softly, VALIDATOR, object, groups);
     }
 
     /**
      * Performs an AssertJ soft assertion that there are <strong>no</strong> constraint violations on the given
      * object using the specified validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param softly    an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator the Validator instance to perform validation with
      * @param object    the object to validate
      * @param groups    the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertNoViolations(SoftAssertions softly,
-                                          Validator validator,
-                                          Object object,
-                                          Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertNoViolations(SoftAssertions softly,
+                                                                     Validator validator,
+                                                                     T object,
+                                                                     Class<?>... groups) {
         var violations = validator.validate(object, groups);
         softly.assertThat(violations).isEmpty();
+        return violations;
     }
 
     /**
@@ -106,9 +116,10 @@ public class ValidationTestHelper {
      *
      * @param object the object to validate
      * @param groups the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertHasViolations(Object object, Class<?>... groups) {
-        assertHasViolations(VALIDATOR, object, groups);
+    public static <T> Set<ConstraintViolation<T>> assertHasViolations(T object, Class<?>... groups) {
+        return assertHasViolations(VALIDATOR, object, groups);
     }
 
     /**
@@ -117,43 +128,54 @@ public class ValidationTestHelper {
      * @param validator the Validator instance to perform validation with
      * @param object    the object to validate
      * @param groups    the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertHasViolations(Validator validator, Object object, Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertHasViolations(Validator validator, T object, Class<?>... groups) {
         var violations = validator.validate(object, groups);
         assertThat(violations)
                 .describedAs("Expected at least one constraint violation")
                 .isNotEmpty();
+        return violations;
     }
 
     /**
      * Performs an AssertJ soft assertion that is at least one constraint violation
      * on the given object using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object the object to validate
      * @param groups the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertHasViolations(SoftAssertions softly, Object object, Class<?>... groups) {
-        assertHasViolations(softly, VALIDATOR, object, groups);
+    public static <T> Set<ConstraintViolation<T>> assertHasViolations(SoftAssertions softly, T object, Class<?>... groups) {
+        return assertHasViolations(softly, VALIDATOR, object, groups);
     }
 
     /**
      * Performs an AssertJ soft assertion that is at least one constraint violation
      * on the given object using the given validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly    an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator the Validator instance to perform validation with
      * @param object    the object to validate
      * @param groups    the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertHasViolations(SoftAssertions softly,
-                                           Validator validator,
-                                           Object object,
-                                           Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertHasViolations(SoftAssertions softly,
+                                                                      Validator validator,
+                                                                      T object,
+                                                                      Class<?>... groups) {
         var violations = validator.validate(object, groups);
         softly.assertThat(violations)
                 .describedAs("Expected at least one constraint violation")
                 .isNotEmpty();
+        return violations;
     }
 
     /**
@@ -163,9 +185,10 @@ public class ValidationTestHelper {
      * @param object                the object to validate
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertViolations(Object object, int numExpectedViolations, Class<?>... groups) {
-        assertViolations(VALIDATOR, object, numExpectedViolations, groups);
+    public static <T> Set<ConstraintViolation<T>> assertViolations(T object, int numExpectedViolations, Class<?>... groups) {
+        return assertViolations(VALIDATOR, object, numExpectedViolations, groups);
     }
 
     /**
@@ -176,48 +199,59 @@ public class ValidationTestHelper {
      * @param object                the object to validate
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertViolations(Validator validator,
-                                        Object object,
-                                        int numExpectedViolations,
-                                        Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertViolations(Validator validator,
+                                                                   T object,
+                                                                   int numExpectedViolations,
+                                                                   Class<?>... groups) {
         var violations = validator.validate(object, groups);
         assertThat(violations).hasSize(numExpectedViolations);
+        return violations;
     }
 
     /**
      * Performs an AssertJ soft assertion that there are exactly {@code numExpectedViolations} constraint violations
      * on the given object using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly                an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object                the object to validate
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertViolations(SoftAssertions softly,
-                                        Object object,
-                                        int numExpectedViolations,
-                                        Class<?>... groups) {
-        assertViolations(softly, VALIDATOR, object, numExpectedViolations, groups);
+    public static <T> Set<ConstraintViolation<T>> assertViolations(SoftAssertions softly,
+                                                                   T object,
+                                                                   int numExpectedViolations,
+                                                                   Class<?>... groups) {
+        return assertViolations(softly, VALIDATOR, object, numExpectedViolations, groups);
     }
 
     /**
      * Performs an AssertJ soft assertion that there are exactly {@code numExpectedViolations} constraint violations
      * on the given object using the specified validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly                an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator             the Validator instance to perform validation with
      * @param object                the object to validate
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertViolations(SoftAssertions softly,
-                                        Validator validator,
-                                        Object object,
-                                        int numExpectedViolations,
-                                        Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertViolations(SoftAssertions softly,
+                                                                   Validator validator,
+                                                                   T object,
+                                                                   int numExpectedViolations,
+                                                                   Class<?>... groups) {
         var violations = validator.validate(object, groups);
         softly.assertThat(violations).hasSize(numExpectedViolations);
+        return violations;
     }
 
     /**
@@ -227,9 +261,10 @@ public class ValidationTestHelper {
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
      * @param groups       the optional validation groups to apply
+     * @return the single {@link ConstraintViolation} object, when the assertion passes
      */
-    public static void assertOnePropertyViolation(Object object, String propertyName, Class<?>... groups) {
-        assertOnePropertyViolation(VALIDATOR, object, propertyName, groups);
+    public static <T> ConstraintViolation<T> assertOnePropertyViolation(T object, String propertyName, Class<?>... groups) {
+        return assertOnePropertyViolation(VALIDATOR, object, propertyName, groups);
     }
 
     /**
@@ -240,46 +275,58 @@ public class ValidationTestHelper {
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
      * @param groups       the optional validation groups to apply
+     * @return the single {@link ConstraintViolation} object, when the assertion passes
      */
-    public static void assertOnePropertyViolation(Validator validator,
-                                                  Object object,
-                                                  String propertyName,
-                                                  Class<?>... groups) {
-        assertPropertyViolations(validator, object, propertyName, 1, groups);
+    public static <T> ConstraintViolation<T> assertOnePropertyViolation(Validator validator,
+                                                                        T object,
+                                                                        String propertyName,
+                                                                        Class<?>... groups) {
+        var constraintViolations = assertPropertyViolations(validator, object, propertyName, 1, groups);
+        return constraintViolations.iterator().next();
     }
 
     /**
      * Performs an AssertJ soft assertion that there is exactly one constraint violation on the given object for the
      * given {@code propertyName} using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values. This is also the reason it returns a
+     * set instead of just a single object.
      *
      * @param softly       an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
      * @param groups       the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertOnePropertyViolation(SoftAssertions softly,
-                                                  Object object,
-                                                  String propertyName,
-                                                  Class<?>... groups) {
-        assertOnePropertyViolation(softly, VALIDATOR, object, propertyName, groups);
+    public static <T> Set<ConstraintViolation<T>> assertOnePropertyViolation(SoftAssertions softly,
+                                                                             T object,
+                                                                             String propertyName,
+                                                                             Class<?>... groups) {
+        return assertOnePropertyViolation(softly, VALIDATOR, object, propertyName, groups);
     }
 
     /**
      * Performs an AssertJ soft assertion that there is exactly one constraint violation on the given object for the
      * given {@code propertyName} using the specified validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values. This is also the reason it returns a
+     * set instead of just a single object.
      *
      * @param softly       an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator    the Validator instance to perform validation with
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
      * @param groups       the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertOnePropertyViolation(SoftAssertions softly,
-                                                  Validator validator,
-                                                  Object object,
-                                                  String propertyName,
-                                                  Class<?>... groups) {
-        assertPropertyViolations(softly, validator, object, propertyName, 1, groups);
+    public static <T> Set<ConstraintViolation<T>> assertOnePropertyViolation(SoftAssertions softly,
+                                                                             Validator validator,
+                                                                             T object,
+                                                                             String propertyName,
+                                                                             Class<?>... groups) {
+        return assertPropertyViolations(softly, validator, object, propertyName, 1, groups);
     }
 
     /**
@@ -313,35 +360,43 @@ public class ValidationTestHelper {
     /**
      * Performs an AssertJ soft assertion that there are <strong>no</strong> constraint violations on the given
      * object for the given {@code propertyName} using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param softly       an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
      * @param groups       the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertNoPropertyViolations(SoftAssertions softly,
-                                                  Object object,
-                                                  String propertyName,
-                                                  Class<?>... groups) {
-        assertNoPropertyViolations(softly, VALIDATOR, object, propertyName, groups);
+    public static <T> Set<ConstraintViolation<T>> assertNoPropertyViolations(SoftAssertions softly,
+                                                                             T object,
+                                                                             String propertyName,
+                                                                             Class<?>... groups) {
+        return assertNoPropertyViolations(softly, VALIDATOR, object, propertyName, groups);
     }
 
     /**
      * Performs an AssertJ soft assertion that there are <strong>no</strong> constraint violations on the given
      * object for the given {@code propertyName} using the specified validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may not be empty.
      *
      * @param softly       an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator    the Validator instance to perform validation with
      * @param object       the object to validate
      * @param propertyName the name of the property to validate on the given object
      * @param groups       the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertNoPropertyViolations(SoftAssertions softly,
-                                                  Validator validator,
-                                                  Object object,
-                                                  String propertyName,
-                                                  Class<?>... groups) {
-        assertPropertyViolations(softly, validator, object, propertyName, 0, groups);
+    public static <T> Set<ConstraintViolation<T>> assertNoPropertyViolations(SoftAssertions softly,
+                                                                             Validator validator,
+                                                                             T object,
+                                                                             String propertyName,
+                                                                             Class<?>... groups) {
+        return assertPropertyViolations(softly, validator, object, propertyName, 0, groups);
     }
 
     /**
@@ -352,12 +407,13 @@ public class ValidationTestHelper {
      * @param propertyName          the name of the property to validate on the given object
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertPropertyViolations(Object object,
-                                                String propertyName,
-                                                int numExpectedViolations,
-                                                Class<?>... groups) {
-        assertPropertyViolations(VALIDATOR, object, propertyName, numExpectedViolations, groups);
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(T object,
+                                                                           String propertyName,
+                                                                           int numExpectedViolations,
+                                                                           Class<?>... groups) {
+        return assertPropertyViolations(VALIDATOR, object, propertyName, numExpectedViolations, groups);
     }
 
     /**
@@ -369,37 +425,46 @@ public class ValidationTestHelper {
      * @param propertyName          the name of the property to validate on the given object
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertPropertyViolations(Validator validator,
-                                                Object object,
-                                                String propertyName,
-                                                int numExpectedViolations,
-                                                Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(Validator validator,
+                                                                           T object,
+                                                                           String propertyName,
+                                                                           int numExpectedViolations,
+                                                                           Class<?>... groups) {
         var propertyViolations = validator.validateProperty(object, propertyName, groups);
         assertThat(propertyViolations).describedAs(propertyName).hasSize(numExpectedViolations);
+        return propertyViolations;
     }
 
     /**
      * Performs an AssertJ soft assertion that there are exactly {@code numExpectedViolations} constraint violations
      * on the given object for the given {@code propertyName} using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly                an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object                the object to validate
      * @param propertyName          the name of the property to validate on the given object
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertPropertyViolations(SoftAssertions softly,
-                                                Object object,
-                                                String propertyName,
-                                                int numExpectedViolations,
-                                                Class<?>... groups) {
-        assertPropertyViolations(softly, VALIDATOR, object, propertyName, numExpectedViolations, groups);
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(SoftAssertions softly,
+                                                                           T object,
+                                                                           String propertyName,
+                                                                           int numExpectedViolations,
+                                                                           Class<?>... groups) {
+        return assertPropertyViolations(softly, VALIDATOR, object, propertyName, numExpectedViolations, groups);
     }
 
     /**
      * Performs an AssertJ soft assertion that there are exactly {@code numExpectedViolations} constraint violations
      * on the given object for the given {@code propertyName} using the specified validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly                an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator             the Validator instance to perform validation with
@@ -407,15 +472,17 @@ public class ValidationTestHelper {
      * @param propertyName          the name of the property to validate on the given object
      * @param numExpectedViolations the number of violations that are expected
      * @param groups                the optional validation groups to apply
+     * @return the set of {@link ConstraintViolation} objects that were found when validating the object
      */
-    public static void assertPropertyViolations(SoftAssertions softly,
-                                                Validator validator,
-                                                Object object,
-                                                String propertyName,
-                                                int numExpectedViolations,
-                                                Class<?>... groups) {
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(SoftAssertions softly,
+                                                                           Validator validator,
+                                                                           T object,
+                                                                           String propertyName,
+                                                                           int numExpectedViolations,
+                                                                           Class<?>... groups) {
         var propertyViolations = validator.validateProperty(object, propertyName, groups);
         softly.assertThat(propertyViolations).describedAs(propertyName).hasSize(numExpectedViolations);
+        return propertyViolations;
     }
 
     /**
@@ -425,9 +492,12 @@ public class ValidationTestHelper {
      * @param object           the object to validate
      * @param propertyName     the name of the property to validate on the given object
      * @param expectedMessages the exact validation messages that are expected
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertPropertyViolations(Object object, String propertyName, String... expectedMessages) {
-        assertPropertyViolations(VALIDATOR, object, propertyName, expectedMessages);
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(T object,
+                                                                           String propertyName,
+                                                                           String... expectedMessages) {
+        return assertPropertyViolations(VALIDATOR, object, propertyName, expectedMessages);
     }
 
     /**
@@ -438,11 +508,12 @@ public class ValidationTestHelper {
      * @param object           the object to validate
      * @param propertyName     the name of the property to validate on the given object
      * @param expectedMessages the exact validation messages that are expected
+     * @return the set of {@link ConstraintViolation} objects, when the assertion passes
      */
-    public static void assertPropertyViolations(Validator validator,
-                                                Object object,
-                                                String propertyName,
-                                                String... expectedMessages) {
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(Validator validator,
+                                                                           T object,
+                                                                           String propertyName,
+                                                                           String... expectedMessages) {
         var propertyViolations = validator.validateProperty(object, propertyName);
         var actualMessages = collectActualMessages(propertyViolations);
         var missingMessages = collectMissingMessages(actualMessages, expectedMessages);
@@ -450,39 +521,49 @@ public class ValidationTestHelper {
         if (isNotNullOrEmpty(missingMessages)) {
             fail(buildFailureMessageForMissingMessages(actualMessages, missingMessages));
         }
+
+        return propertyViolations;
     }
 
     /**
      * Performs an AssertJ soft assertion that the constraint violations match {@code expectedMessages} on the given
      * object for the given {@code propertyName} using a default validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly           an AssertJ SoftAssertions instance for collecting multiple errors
      * @param object           the object to validate
      * @param propertyName     the name of the property to validate on the given object
      * @param expectedMessages the exact validation messages that are expected
+     * @return the set of {@link ConstraintViolation} objects
      */
-    public static void assertPropertyViolations(SoftAssertions softly,
-                                                Object object,
-                                                String propertyName,
-                                                String... expectedMessages) {
-        assertPropertyViolations(softly, VALIDATOR, object, propertyName, expectedMessages);
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(SoftAssertions softly,
+                                                                           T object,
+                                                                           String propertyName,
+                                                                           String... expectedMessages) {
+        return assertPropertyViolations(softly, VALIDATOR, object, propertyName, expectedMessages);
     }
 
     /**
      * Performs an AssertJ soft assertion that the constraint violations match {@code expectedMessages} on the given
      * object for the given {@code propertyName} using the specified validator.
+     * <p>
+     * Because this uses {@link SoftAssertions} and does not fail immediately, the returned set of
+     * constraint violations may or may not have the expected values.
      *
      * @param softly           an AssertJ SoftAssertions instance for collecting multiple errors
      * @param validator        the Validator instance to perform validation with
      * @param object           the object to validate
      * @param propertyName     the name of the property to validate on the given object
      * @param expectedMessages the exact validation messages that are expected
+     * @return the set of {@link ConstraintViolation} objects
      */
-    public static void assertPropertyViolations(SoftAssertions softly,
-                                                Validator validator,
-                                                Object object,
-                                                String propertyName,
-                                                String... expectedMessages) {
+    public static <T> Set<ConstraintViolation<T>> assertPropertyViolations(SoftAssertions softly,
+                                                                           Validator validator,
+                                                                           T object,
+                                                                           String propertyName,
+                                                                           String... expectedMessages) {
         var propertyViolations = validator.validateProperty(object, propertyName);
         var actualMessages = collectActualMessages(propertyViolations);
         var missingMessages = collectMissingMessages(actualMessages, expectedMessages);
@@ -490,9 +571,11 @@ public class ValidationTestHelper {
         if (isNotNullOrEmpty(missingMessages)) {
             softly.fail(buildFailureMessageForMissingMessages(actualMessages, missingMessages));
         }
+
+        return propertyViolations;
     }
 
-    private static List<String> collectActualMessages(Set<ConstraintViolation<Object>> violations) {
+    private static <T> List<String> collectActualMessages(Set<ConstraintViolation<T>> violations) {
         return violations.stream()
                 .map(ConstraintViolation::getMessage)
                 .collect(toList());

--- a/src/test/java/org/kiwiproject/test/validation/SoftValidationTestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/validation/SoftValidationTestAssertionsTest.java
@@ -10,9 +10,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.PositiveOrZero;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("SoftValidationTestAssertions")
 @ExtendWith(SoftAssertionsExtension.class)
@@ -55,7 +59,8 @@ class SoftValidationTestAssertionsTest {
         void shouldVerifyNoViolations(SoftAssertions softly) {
             var alice = new Person("Alice", "Mayberry", 32, null);
 
-            newSoftValidation(softly).assertNoViolations(alice);
+            var constraintViolations = newSoftValidation(softly).assertNoViolations(alice);
+            assertThat(constraintViolations).isEmpty();
         }
     }
 
@@ -68,10 +73,17 @@ class SoftValidationTestAssertionsTest {
 
             softValidation = newSoftValidation(softly);
 
-            softValidation.assertNoPropertyViolations(alice, "firstName");
-            softValidation.assertNoPropertyViolations(alice, "lastName");
-            softValidation.assertNoPropertyViolations(alice, "age");
-            softValidation.assertNoPropertyViolations(alice, "nickname");
+            var firstNameViolations = softValidation.assertNoPropertyViolations(alice, "firstName");
+            assertThat(firstNameViolations).isEmpty();
+
+            var lastNameViolations = softValidation.assertNoPropertyViolations(alice, "lastName");
+            assertThat(lastNameViolations).isEmpty();
+
+            var ageViolations = softValidation.assertNoPropertyViolations(alice, "age");
+            assertThat(ageViolations).isEmpty();
+
+            var nicknameViolations = softValidation.assertNoPropertyViolations(alice, "nickname");
+            assertThat(nicknameViolations).isEmpty();
         }
     }
 
@@ -82,7 +94,8 @@ class SoftValidationTestAssertionsTest {
         void shouldVerifyExpectedNumberOfViolationsForObject(SoftAssertions softly) {
             var alice = new Person("", "Mayberry", 132, null);
 
-            newSoftValidation(softly).assertViolations(alice, 2);
+            var constraintViolations = newSoftValidation(softly).assertViolations(alice, 2);
+            assertThat(constraintViolations).hasSize(2);
         }
     }
 
@@ -95,10 +108,17 @@ class SoftValidationTestAssertionsTest {
 
             softValidation = newSoftValidation(softly);
 
-            softValidation.assertPropertyViolations(alice, "firstName", 1);
-            softValidation.assertPropertyViolations(alice, "lastName", 2);
-            softValidation.assertPropertyViolations(alice, "age", 1);
-            softValidation.assertPropertyViolations(alice, "nickname", 0);
+            var firstNameViolations = softValidation.assertPropertyViolations(alice, "firstName", 1);
+            assertThat(firstNameViolations).hasSize(1);
+
+            var lastNameViolations = softValidation.assertPropertyViolations(alice, "lastName", 2);
+            assertThat(lastNameViolations).hasSize(2);
+
+            var ageViolations = softValidation.assertPropertyViolations(alice, "age", 1);
+            assertThat(ageViolations).hasSize(1);
+
+            var nicknameViolations = softValidation.assertPropertyViolations(alice, "nickname", 0);
+            assertThat(nicknameViolations).isEmpty();
         }
     }
 
@@ -124,7 +144,12 @@ class SoftValidationTestAssertionsTest {
         void shouldVerifyOneViolationForMultipleProperties(SoftAssertions softly) {
             var alice = new Person("", null, 132, null);
 
-            newSoftValidation(softly).assertPropertiesEachHaveOneViolation(alice, "firstName", "lastName", "age");
+            var constraintViolations = newSoftValidation(softly)
+                    .assertPropertiesEachHaveOneViolation(alice, "firstName", "lastName", "age");
+            assertThat(constraintViolations)
+                    .extracting(ConstraintViolation::getPropertyPath)
+                    .map(Objects::toString)
+                    .containsExactlyInAnyOrder("firstName", "lastName", "age");
         }
     }
 
@@ -135,7 +160,9 @@ class SoftValidationTestAssertionsTest {
         void shouldVerifyNoViolationsForMultipleProperties(SoftAssertions softly) {
             var alice = new Person("Alice", "Mayberry", 32, null);
 
-            newSoftValidation(softly).assertPropertiesEachHaveNoViolations(alice, "firstName", "lastName", "age");
+            var constraintViolations = newSoftValidation(softly)
+                    .assertPropertiesEachHaveNoViolations(alice, "firstName", "lastName", "age");
+            assertThat(constraintViolations).isEmpty();
         }
     }
 


### PR DESCRIPTION
Change void methods in SoftValidationTestAssertions and ValidationTestHelper to return a Set of ConstraintViolation objects or a single ConstraintViolation object, as appropriate.

The void methods in ValidationTestHelper that validate there are no violations, and which do not use SoftAssertions, remain as void. This is simply because when the assertion passes, the set of constraint violations will always be empty, so returning it provides no value.

Perhaps surprisingly at first, the validation methods using SoftAssertions always have a return value. Because of how soft assertions work (i.e. they collect errors and do not fail immediately), you cannot know exactly what the validation results are, so we therefore always have to return the violations for inspection. For example, validating that there are two errors on an object using soft assertions when there are actually none, will result in a Set of ConstraintViolation objects being returned that is empty. So, any further (soft or not) assertions performed on the returned Set will also result in errors. Or, validating that there are no errors on an object, again using soft assertions, when there are actually three errors, will return a Set of ConstraintViolation that contains those three errors. When using soft assertions, the return values will be most useful to perform additional (soft) assertions on the ConstraintViolation objects, but they may also be useful during debugging such as when you aren't expecting any validation errors but there are some.

Closes #403