### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['11', '17', '20']
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -61,16 +61,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>kiwi-test</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_kiwi-test</sonar.projectKey>
@@ -126,7 +126,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTests.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTests.java
@@ -6,7 +6,7 @@ import static java.util.stream.Collectors.toSet;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.JettyManaged;

--- a/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.test.dropwizard.app;
 
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;

--- a/src/main/java/org/kiwiproject/test/dropwizard/configuration/DropwizardConfigurations.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/configuration/DropwizardConfigurations.java
@@ -4,15 +4,15 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.test.constants.KiwiTestConstants.OBJECT_MAPPER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.Configuration;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.core.Configuration;
+import jakarta.validation.Validator;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.test.constants.KiwiTestConstants;
 import org.kiwiproject.test.validation.ValidationTestHelper;
 
-import javax.validation.Validator;
 import java.io.File;
 import java.nio.file.Path;
 

--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoContext.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoContext.java
@@ -3,16 +3,15 @@ package org.kiwiproject.test.dropwizard.mockito;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.core.setup.AdminEnvironment;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.AdminEnvironment;
-import io.dropwizard.setup.Environment;
+import jakarta.validation.Validator;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
-
-import javax.validation.Validator;
 
 /**
  * Contains all the various top-level objects in a Dropwizard application.

--- a/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocks.java
@@ -9,15 +9,14 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Verify;
+import io.dropwizard.core.setup.AdminEnvironment;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.AdminEnvironment;
-import io.dropwizard.setup.Environment;
+import jakarta.validation.Validator;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.test.validation.ValidationTestHelper;
 import org.mockito.Mockito;
-
-import javax.validation.Validator;
 
 /**
  * Creates Mockito mocks of Dropwizard application level objects.

--- a/src/main/java/org/kiwiproject/test/jaxrs/JaxrsTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/jaxrs/JaxrsTestHelper.java
@@ -5,12 +5,12 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 import lombok.experimental.UtilityClass;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 import java.util.Map;
 
 /**

--- a/src/main/java/org/kiwiproject/test/jaxrs/RequestResponseLogger.java
+++ b/src/main/java/org/kiwiproject/test/jaxrs/RequestResponseLogger.java
@@ -1,9 +1,9 @@
 package org.kiwiproject.test.jaxrs;
 
+import jakarta.ws.rs.client.Client;
 import lombok.experimental.UtilityClass;
 import org.glassfish.jersey.logging.LoggingFeature;
 
-import javax.ws.rs.client.Client;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;

--- a/src/main/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelper.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.collect.KiwiLists.first;
 
+import jakarta.ws.rs.core.Response;
 import lombok.experimental.UtilityClass;
 import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
 import org.kiwiproject.jaxrs.exception.ErrorMessage;
 import org.kiwiproject.jaxrs.exception.JaxrsException;
 import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
 
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtension.java
@@ -1,14 +1,13 @@
 package org.kiwiproject.test.junit.jupiter;
 
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.kiwiproject.validation.KiwiValidations;
 
-import javax.validation.Validator;
-
 /**
  * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension} that resets the (static)
- * {@link javax.validation.Validator} used in {@link KiwiValidations}.
+ * {@link jakarta.validation.Validator} used in {@link KiwiValidations}.
  *
  * @see KiwiValidations#setValidator(Validator)
  * @see KiwiValidations#getValidator()

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
  * <p>
  * <strong>However</strong>, unlike {@link BlankStringArgumentsProvider}, this will only use characters that fall
  * in the ASCII character set. Unless it is absolutely necessary to test against ASCII only whitespace (for example, to
- * validate using the Bean Validation API's {@link javax.validation.constraints.NotBlank NotBlank} annotation), it is
+ * validate using the Bean Validation API's {@link jakarta.validation.constraints.NotBlank NotBlank} annotation), it is
  * recommended you use {@link BlankStringArgumentsProvider} instead.
  * <p>
  * Usage:

--- a/src/main/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelper.java
@@ -6,10 +6,10 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.stream.IntStreams.indicesOf;
 import static org.kiwiproject.test.junit.ParameterizedTests.inputs;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import org.assertj.core.api.SoftAssertions;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;

--- a/src/main/java/org/kiwiproject/test/validation/SoftValidationTestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/validation/SoftValidationTestAssertions.java
@@ -1,13 +1,13 @@
 package org.kiwiproject.test.validation;
 
+import static java.util.stream.Collectors.toSet;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import org.assertj.core.api.SoftAssertions;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
 import java.util.Arrays;
 import java.util.Set;
-
-import static java.util.stream.Collectors.toSet;
 
 /**
  * A helper class with methods for making AssertJ {@link SoftAssertions} when validating objects using the

--- a/src/main/java/org/kiwiproject/test/validation/ValidationTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/validation/ValidationTestHelper.java
@@ -1,20 +1,20 @@
 package org.kiwiproject.test.validation;
 
-import lombok.experimental.UtilityClass;
-import org.assertj.core.api.SoftAssertions;
-import org.kiwiproject.base.KiwiStrings;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.kiwiproject.collect.KiwiLists.isNotNullOrEmpty;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import lombok.experimental.UtilityClass;
+import org.assertj.core.api.SoftAssertions;
+import org.kiwiproject.base.KiwiStrings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Provides helper methods for making assertions on validation of objects using the Bean Validation API.

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
@@ -6,15 +6,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 
 import com.codahale.metrics.health.HealthCheck;
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.JettyManaged;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
-import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,8 +28,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
 import java.util.List;
 
 @DisplayName("DropwizardAppTests")
@@ -37,7 +37,7 @@ class DropwizardAppTestsTest {
 
     @Getter
     @Setter
-    static class Config extends Configuration {
+    public static class Config extends Configuration {
         private String tagLine;
         private String answer;
     }
@@ -111,7 +111,7 @@ class DropwizardAppTestsTest {
             environment.lifecycle().manage(new Managed1());
             environment.lifecycle().manage(new Managed2());
 
-            environment.lifecycle().addLifeCycleListener(new MyLifeCycleListener());
+            environment.lifecycle().addEventListener(new MyLifeCycleListener());
             environment.lifecycle().addServerLifecycleListener(new MyServerLifecycleListener());
         }
     }

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.junit.jupiter.api.AfterAll;
@@ -16,10 +19,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 @DisplayName("PostgresAppTestExtension: ConfigOverrides")
 class PostgresAppTestExtensionConfigOverridesTest {

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.setup.Environment;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.junit.jupiter.api.AfterAll;
@@ -15,9 +17,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 /**
  * Tests that we can specify a custom name in the configuration for the DataSourceFactory.

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.Application;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.setup.Environment;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.junit.jupiter.api.AfterAll;
@@ -15,9 +17,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 @DisplayName("PostgresAppTestExtension")
 class PostgresAppTestExtensionTest {

--- a/src/test/java/org/kiwiproject/test/dropwizard/configuration/DropwizardConfigurationsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/configuration/DropwizardConfigurationsTest.java
@@ -5,9 +5,14 @@ import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dropwizard.Configuration;
 import io.dropwizard.configuration.ConfigurationValidationException;
+import io.dropwizard.core.Configuration;
 import io.dropwizard.testing.ResourceHelpers;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.assertj.core.api.SoftAssertions;
@@ -17,11 +22,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;

--- a/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/mockito/DropwizardMockitoMocksTest.java
@@ -7,9 +7,10 @@ import static org.mockito.Mockito.mock;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.base.VerifyException;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.setup.Environment;
+import jakarta.validation.Validation;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,8 +19,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.test.validation.ValidationTestHelper;
 import org.mockito.Mockito;
-
-import javax.validation.Validation;
 
 @DisplayName("DropwizardMockitoMocks")
 class DropwizardMockitoMocksTest {

--- a/src/test/java/org/kiwiproject/test/jaxrs/JaxrsTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/JaxrsTestHelperTest.java
@@ -7,6 +7,7 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.core.Response;
 import lombok.Value;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.kiwiproject.jaxrs.KiwiResponses;
 import org.opentest4j.AssertionFailedError;
 
-import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;

--- a/src/test/java/org/kiwiproject/test/jaxrs/RequestResponseLoggerTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/RequestResponseLoggerTest.java
@@ -7,6 +7,12 @@ import static org.kiwiproject.collect.KiwiLists.second;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import lombok.Getter;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,12 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
@@ -7,6 +7,12 @@ import static org.assertj.core.api.Assertions.entry;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,12 +27,6 @@ import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
 import org.kiwiproject.jaxrs.exception.JaxrsNotFoundException;
 import org.kiwiproject.test.jaxrs.RequestResponseLogger;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 

--- a/src/test/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelperTest.java
@@ -15,6 +15,10 @@ import static org.kiwiproject.test.validation.ParameterizedValidationTestHelper.
 import static org.kiwiproject.test.validation.ParameterizedValidationTestHelper.noExpectedMessages;
 import static org.kiwiproject.test.validation.ParameterizedValidationTestHelper.validationGroups;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Past;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,10 +32,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import javax.validation.constraints.Past;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Date;

--- a/src/test/java/org/kiwiproject/test/validation/SoftValidationTestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/validation/SoftValidationTestAssertionsTest.java
@@ -1,5 +1,11 @@
 package org.kiwiproject.test.validation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Builder;
 import lombok.Value;
 import org.assertj.core.api.SoftAssertions;
@@ -10,13 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.PositiveOrZero;
 import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("SoftValidationTestAssertions")
 @ExtendWith(SoftAssertionsExtension.class)

--- a/src/test/java/org/kiwiproject/test/validation/ValidationTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/validation/ValidationTestHelperTest.java
@@ -12,6 +12,14 @@ import static org.kiwiproject.test.validation.ValidationTestHelper.assertViolati
 import static org.kiwiproject.test.validation.ValidationTestHelper.getValidator;
 import static org.kiwiproject.test.validation.ValidationTestHelper.newValidator;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Path;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.groups.Default;
 import lombok.Builder;
 import lombok.Value;
 import lombok.With;
@@ -25,14 +33,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Path;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import javax.validation.constraints.PositiveOrZero;
-import javax.validation.groups.Default;
 import java.util.function.Consumer;
 
 @DisplayName("ValidationTestHelper")


### PR DESCRIPTION
* Bump version to 3.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9

Closes #412