### PR TITLE
Fix javadoc in DropwizardAppTests#registeredResourceClassesOf

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTests.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTests.java
@@ -83,7 +83,7 @@ public class DropwizardAppTests {
      * @param jersey the {@link JerseyEnvironment} associated with the Dropwizard app being tested
      * @return set containing registered resource objects
      * @implNote Dropwizard 2.0 added one more layer of indirection for resource endpoint classes; they are now
-     * wrapper inside a {@link DropwizardResourceConfig.SpecificBinder} so this method needs to unwrap those and
+     * wrapped inside a {@link DropwizardResourceConfig.SpecificBinder}, so this method needs to unwrap those and
      * add the wrapped objects to the returned set. To accomplish that, it has to perform some nastiness with the
      * {@link org.glassfish.jersey.internal.inject.Binding} returned by
      * {@link DropwizardResourceConfig.SpecificBinder#getBindings()}, specifically it must cast to


### PR DESCRIPTION
* 'they are now wrapper inside' should be 'they are now wrapped inside'
* Add a comma after the 'so' for clarity