### PR TITLE
Add InMemoryAppenderAssertions and test for InMemoryAppender

### DIFF
--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppender.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppender.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
+import com.google.common.annotations.Beta;
 import lombok.Synchronized;
 
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.stream.Stream;
  * <p>
  * <em>This is for testing purposes only, and is not at all intended for production use!</em>
  */
+@Beta
 public class InMemoryAppender extends AppenderBase<ILoggingEvent> {
 
     private final AtomicInteger messageOrder;

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderAssertions.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderAssertions.java
@@ -1,0 +1,74 @@
+package org.kiwiproject.test.logback;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.google.common.annotations.Beta;
+import org.assertj.core.api.Assertions;
+
+import java.util.List;
+
+/**
+ * Provides AssertJ assertions for {@link InMemoryAppender}.
+ */
+@Beta
+public class InMemoryAppenderAssertions {
+
+    private final InMemoryAppender appender;
+
+    private InMemoryAppenderAssertions(InMemoryAppender appender) {
+        this.appender = appender;
+    }
+
+    /**
+     * Begin assertions for an {@link InMemoryAppender}.
+     *
+     * @param appender the appender to assert against
+     * @return a new InMemoryAppenderAssertions instance
+     */
+    public static InMemoryAppenderAssertions assertThat(InMemoryAppender appender) {
+        return new InMemoryAppenderAssertions(appender);
+    }
+
+    /**
+     * Assert this appender has the expected number of logging events, and if the assertion succeeds, return a
+     * list containing those events.
+     *
+     * @return a List containing the logging events
+     */
+    public List<ILoggingEvent> hasNumberOfLoggingEventsAndGet(int expectedEventCount) {
+        return hasNumberOfLoggingEvents(expectedEventCount).andGetOrderedEvents();
+    }
+
+    /**
+     * Assert this appender has the expected number of logging events, and if the assertion succeeds, return this
+     * instance to continue chaining assertions.
+     *
+     * @return this instance
+     */
+    public InMemoryAppenderAssertions hasNumberOfLoggingEvents(int expectedEventCount) {
+        var events = appender.orderedEvents();
+        Assertions.assertThat(events).hasSize(expectedEventCount);
+        return this;
+    }
+
+    /**
+     * Assert this appender contains the given message at least once (but possibly more than once).
+     *
+     * @param message the exact message to find
+     * @return this instance
+     */
+    public InMemoryAppenderAssertions containsMessage(String message) {
+        var messages = appender.orderedEvents().stream().map(ILoggingEvent::getMessage).toList();
+        Assertions.assertThat(messages).contains(message);
+        return this;
+    }
+
+    /**
+     * A terminal method if you want to get the actual logging events after performing assertions, for example,
+     * to perform additional inspections. Does not perform any assertions.
+     *
+     * @return a List containing the logging events
+     */
+    public List<ILoggingEvent> andGetOrderedEvents() {
+        return appender.orderedEvents();
+    }
+}

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -3,6 +3,7 @@ package org.kiwiproject.test.logback;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Logger;
+import com.google.common.annotations.Beta;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -16,6 +17,7 @@ import org.slf4j.LoggerFactory;
  * Uses {@link InMemoryAppender} to store logged messages, so that tests
  * can retrieve and verify them later.
  */
+@Beta
 public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachCallback {
 
     private final Class<?> loggerClass;

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderTest.java
@@ -1,0 +1,188 @@
+package org.kiwiproject.test.logback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.kiwiproject.collect.KiwiLists.first;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+@DisplayName("InMemoryAppender")
+@Slf4j
+class InMemoryAppenderTest {
+
+    @RegisterExtension
+    private final InMemoryAppenderExtension inMemoryAppenderExtension =
+            new InMemoryAppenderExtension(InMemoryAppenderTest.class);
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        appender = inMemoryAppenderExtension.appender();
+    }
+
+    @Test
+    void shouldAppendAnEvent() {
+        LOG.info("Hello, logger");
+
+        assertThat(appender.orderedEvents()).hasSize(1);
+        var event = first(appender.orderedEvents());
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getFormattedMessage()).isEqualTo("Hello, logger");
+    }
+
+    @Nested
+    class GetEventMap {
+
+        @BeforeEach
+        void setUp() {
+            LOG.info("Message A");
+            LOG.debug("Message B");
+            LOG.warn("Message C");
+            LOG.error("Message D");
+        }
+
+        @Test
+        void shouldReturnEvents() {
+            var eventMap = appender.eventMap();
+
+            assertThat(eventMap.get(1).getFormattedMessage()).isEqualTo("Message A");
+            assertThat(eventMap.get(2).getFormattedMessage()).isEqualTo("Message B");
+            assertThat(eventMap.get(3).getFormattedMessage()).isEqualTo("Message C");
+            assertThat(eventMap.get(4).getFormattedMessage()).isEqualTo("Message D");
+        }
+
+        @Test
+        void shouldReturnUnmodifiableCopyOfEventMap() {
+            var eventMap = appender.eventMap();
+
+            var newEvent = new LoggingEvent();
+            assertThatThrownBy(() -> eventMap.put(2, newEvent)).isExactlyInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void shouldReturnCopyOfEventMap() {
+            var originalEventMap = appender.eventMap();
+
+            LOG.info("Another message");
+            LOG.debug("And another");
+
+            var newEventMap = appender.eventMap();
+            assertThat(newEventMap).hasSize(originalEventMap.size() + 2);
+        }
+    }
+
+    @Test
+    void shouldReturnEventsInOrderTheyWereLogged() {
+        LOG.info("Message 1");
+        LOG.debug("Message 2");
+        LOG.warn("Message 3");
+
+        assertThat(appender.orderedEvents())
+                .extracting("level", "formattedMessage")
+                .containsExactly(
+                        tuple(Level.INFO, "Message 1"),
+                        tuple(Level.DEBUG, "Message 2"),
+                        tuple(Level.WARN, "Message 3")
+                );
+    }
+
+    @Test
+    void shouldReturnOrderedLogMessages() {
+        LOG.info("Message 1");
+        LOG.debug("Message 2");
+        LOG.warn("Message 3");
+        LOG.error("Message 4");
+
+        assertThat(appender.orderedEventMessages()).containsExactly(
+                "Message 1",
+                "Message 2",
+                "Message 3",
+                "Message 4"
+        );
+    }
+
+    @Test
+    void shouldClearAllLoggingEvents() {
+        IntStream.range(0, 10).forEach(i -> LOG.debug("Message {}", i));
+        assertThat(appender.orderedEvents()).hasSize(10);
+
+        appender.clearEvents();
+
+        assertThat(appender.orderedEvents()).isEmpty();
+    }
+
+    @Nested
+    class EventAssertions {
+
+        @Test
+        void shouldAssertWhenEmpty() {
+            var events = InMemoryAppenderAssertions.assertThat(appender).hasNumberOfLoggingEventsAndGet(0);
+            assertThat(events).isEmpty();
+        }
+
+        @Test
+        void shouldAssertWhenContainsLoggingEvents() {
+            var messages = IntStream.range(0, 5).mapToObj(i -> "Message " + i).toArray(String[]::new);
+            Arrays.stream(messages).forEach(LOG::debug);
+
+            var eventsRef = new AtomicReference<List<ILoggingEvent>>();
+            assertThatCode(() -> {
+                var loggingEvents = InMemoryAppenderAssertions.assertThat(appender).hasNumberOfLoggingEventsAndGet(5);
+                eventsRef.set(loggingEvents);
+            }).doesNotThrowAnyException();
+
+            var events = eventsRef.get();
+            assertThat(events).extracting(ILoggingEvent::getFormattedMessage).containsExactly(messages);
+        }
+
+        @Test
+        void shouldAssertNumberOfLoggingEventsOnly() {
+            var messages = IntStream.range(0, 5).mapToObj(i -> "Message " + i).toArray(String[]::new);
+            Arrays.stream(messages).forEach(LOG::debug);
+
+            assertThatCode(() -> InMemoryAppenderAssertions.assertThat(appender).hasNumberOfLoggingEventsAndGet(5))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldGetOrderedLoggingEventsOnly() {
+            var messages = IntStream.range(0, 5).mapToObj(i -> "Message " + i).toArray(String[]::new);
+            Arrays.stream(messages).forEach(LOG::debug);
+
+            List<ILoggingEvent> events = InMemoryAppenderAssertions.assertThat(appender).andGetOrderedEvents();
+            assertThat(events).extracting(ILoggingEvent::getFormattedMessage).containsExactly(messages);
+        }
+
+        @Test
+        void shouldCheckContainsMessageWhenItExists() {
+            var messages = IntStream.range(0, 5).mapToObj(i -> "Message " + i).toArray(String[]::new);
+            Arrays.stream(messages).forEach(LOG::debug);
+
+            assertThatCode(() -> InMemoryAppenderAssertions.assertThat(appender).containsMessage("Message 0").containsMessage("Message 4"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckContainsMessageWhenItDoesNotExist() {
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> InMemoryAppenderAssertions.assertThat(appender).containsMessage("Message 0"));
+        }
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -18,6 +18,14 @@
         <appender-ref ref="LoggingComparisonListenerTestAppender"/>
     </logger>
 
+    <!-- This is required for InMemoryAppenderTest -->
+    <appender name="InMemoryAppenderTestAppender" class="org.kiwiproject.test.logback.InMemoryAppender"/>
+
+    <!-- This is required for InMemoryAppenderTest -->
+    <logger name="org.kiwiproject.test.logback.InMemoryAppenderTest" level="DEBUG">
+        <appender-ref ref="InMemoryAppenderTestAppender"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
* Add InMemoryAppenderAssertions, which is copied from kiwi-beta and modified due to differences in method names (the InMemoryAppender here does not prefix methods with "get").
* Add test for InMemoryAppender, copied from kiwi-beta and modified.
* Add necessary appender and logger to logback-test.xml.
* Mark InMemoryAppender, InMemoryAppenderAssertions, and InMemoryAppenderExtension with Beta annotation