### PR TITLE
Add try/catch to Jdbi#withHandle inside Mockito#when in Jdbi3HelpersTest

### DIFF
--- a/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3HelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3HelpersTest.java
@@ -167,7 +167,11 @@ class Jdbi3HelpersTest {
 
         @SuppressWarnings("unchecked")
         private OngoingStubbing<Object> whenWithHandleCalled() {
-            return when(jdbi.withHandle(any(HandleCallback.class)));
+            try {
+                return when(jdbi.withHandle(any(HandleCallback.class)));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
Add a try/catch inside the FindDatabasePlugin#whenWithHandleCalled method to make VSCode (I guess really the Red Hat Java extension) happy. For some reason, it always complains that about "Unhandled exception type Exception Java(16777384)".

It apparently "thinks" the exception thrown by the Jdbi#withHandle method, which is called inside the Mockito#when method, must be handled.

Neither Maven nor IntelliJ have any problems with the code, and they compile it and run it just fine.

But whenever I need to pop into Gitpod and do something, this code is flagged by VSCode/Red Hat Java Extension. So, the easiest thing to do is just appease it and add a try/catch around that code. If an exception is thrown, wrap with a RuntimeException.