### PR TITLE
Create utils and Jupiter extension to reset Logback

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.test.junit.jupiter;
 
-import ch.qos.logback.classic.ClassicConstants;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -61,12 +62,15 @@ import org.kiwiproject.test.logback.LogbackTestHelpers;
 public class ResetLogbackLoggingExtension implements AfterAllCallback {
 
     @Getter
-    @Builder.Default
-    private final String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
+    private String logbackConfigFilePath;
 
     @Override
     public void afterAll(ExtensionContext context) {
-        LogbackTestHelpers.resetLogback(logbackConfigFilePath);
+        if (isBlank(logbackConfigFilePath)) {
+            LogbackTestHelpers.resetLogback();
+        } else {
+            LogbackTestHelpers.resetLogback(logbackConfigFilePath);
+        }
         LOG.info("Logback was reset using configuration: {}", logbackConfigFilePath);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -1,16 +1,14 @@
 package org.kiwiproject.test.junit.jupiter;
 
+import ch.qos.logback.classic.ClassicConstants;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.kiwiproject.test.logback.LogbackTestHelpers;
-
-import ch.qos.logback.classic.ClassicConstants;
 
 /**
  * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to reset
@@ -64,7 +62,7 @@ public class ResetLogbackLoggingExtension implements AfterAllCallback {
     private String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
 
     @Override
-    public void afterAll(ExtensionContext context) throws Exception {
+    public void afterAll(ExtensionContext context) {
         LogbackTestHelpers.resetLogback(logbackConfigFilePath);
         LOG.info("Logback was reset using configuration: {}", logbackConfigFilePath);
     }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.ClassicConstants;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -56,10 +57,12 @@ import org.kiwiproject.test.logback.LogbackTestHelpers;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
+@SuppressWarnings("LombokGetterMayBeUsed")
 public class ResetLogbackLoggingExtension implements AfterAllCallback {
 
+    @Getter
     @Builder.Default
-    private String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
+    private final String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
 
     @Override
     public void afterAll(ExtensionContext context) {

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -1,0 +1,71 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.logback.LogbackTestHelpers;
+
+import ch.qos.logback.classic.ClassicConstants;
+
+/**
+ * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to reset
+ * the Logback logging system after all tests have completed.
+ * <p>
+ * This is useful if something misbehaves, for example Dropwizard's
+ * <a href="https://www.dropwizard.io/en/stable/manual/testing.html#integration-testing">DropwizardAppExtension</a> and
+ * <a href="https://www.dropwizard.io/en/stable/manual/testing.html#testing-client-implementations">DropwizardClientExtension</a>
+ * extensions both stop and detach all appenders after all tests complete! Both of those extensions
+ * reset Logback in
+ * <a href="https://github.com/dropwizard/dropwizard/blob/297870e3b4b43ea9fb19417dd90ed78151cf6f5d/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L244">DropwizardTestSupport</a>.
+ * Once this happens, there is no logging output from subsequent tests (since there are no more appenders).
+ * We consider this to be <em>bad</em>, since logging output is useful to track down causes if
+ * there are other test failures. And, it's just not nice behavior to completely hijack logging!
+ * <p>
+ * You can use this extension in tests that are using misbehaving components to ensure that Logback
+ * is reset after all tests complete, so that subsequent tests have log output.
+ * <p>
+ * For example to use the default {@code logback-test.xml} as the logging configuration you
+ * can just use {@code @ExtendWith} on the test class:
+ * <pre>
+ *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
+ *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class)
+ *   class CustomClientTest {
+ *
+ *       // test code that uses DropwizardClientExtension
+ *   }
+ * </pre>
+ * Alternatively, you can register the extension programmatically to use a custom
+ * logging configuration:
+ * <pre>
+ *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
+ *   class CustomClientTest {
+ *
+ *      {@literal @}RegisterExtension
+ *       static final ResetLogbackLoggingExtension RESET_LOGBACK = ResetLogbackLoggingExtension.builder()
+ *               .logbackConfigFilePath("acme-special-logback.xml")
+ *               .build();
+ *
+ *       // test code that uses DropwizardClientExtension
+ *   }
+ * </pre>
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@Slf4j
+public class ResetLogbackLoggingExtension implements AfterAllCallback {
+
+    @Builder.Default
+    private String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        LogbackTestHelpers.resetLogback(logbackConfigFilePath);
+        LOG.info("Logback was reset using configuration: {}", logbackConfigFilePath);
+    }
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.test.junit.jupiter;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
+import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.kiwiproject.test.logback.LogbackTestHelpers;
+import org.kiwiproject.test.logback.LogbackTestHelper;
 
 /**
  * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to reset
@@ -66,11 +65,13 @@ public class ResetLogbackLoggingExtension implements AfterAllCallback {
 
     @Override
     public void afterAll(ExtensionContext context) {
-        if (isBlank(logbackConfigFilePath)) {
-            LogbackTestHelpers.resetLogback();
-        } else {
-            LogbackTestHelpers.resetLogback(logbackConfigFilePath);
-        }
-        LOG.info("Logback was reset using configuration: {}", logbackConfigFilePath);
+        getLogbackTestHelper().resetLogbackWithDefaultOrConfig(logbackConfigFilePath);
+        LOG.debug("Logback was reset using configuration: {} (if null, the Logback defaults are used)",
+                logbackConfigFilePath);
+    }
+
+    @VisibleForTesting
+    protected LogbackTestHelper getLogbackTestHelper() {
+        return new LogbackTestHelper();
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -60,6 +60,12 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
 @SuppressWarnings("LombokGetterMayBeUsed")
 public class ResetLogbackLoggingExtension implements AfterAllCallback {
 
+    /**
+     * A custom location for the Logback configuration.
+     * <p>
+     * If this is not set, then the default Logback configuration files are used
+     * in the order {@code logback-test.xml} followed by {@code logback.xml}.
+     */
     @Getter
     private String logbackConfigFilePath;
 

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -102,15 +102,19 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
     }
 
     /**
-     * The Logback configuration to use if the logging system needs to be reset.
+     * The custom Logback configuration to use if the logging system needs to be reset.
      * <p>
      * For example:
+     *
      * <pre>
      * {@literal @}RegisterExtension
      *  private final InMemoryAppenderExtension inMemoryAppenderExtension =
      *          new InMemoryAppenderExtension(InMemoryAppenderTest.class)
      *                  .withLogbackConfigFilePath("acme-logback-test.xml");
      * </pre>
+     *
+     * If this is not set, then the default Logback configuration files are used
+     * in the order {@code logback-test.xml} followed by {@code logback.xml}.
      *
      * @param logbackConfigFilePath the location of the custom Logback configuration file
      * @return this extension, so this can be chained after the constructor

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -1,9 +1,9 @@
 package org.kiwiproject.test.logback;
 
 import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -33,9 +33,8 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
     private final Class<?> loggerClass;
     private final String appenderName;
 
-    // Use the default Logback test configuration file as our default value.
     @Getter
-    private String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
+    private String logbackConfigFilePath;
 
     @Getter
     @Accessors(fluent = true)
@@ -177,7 +176,11 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
         System.out.println("You can customize the logging configuration using #withLogbackConfigFilePath");
 
         // Reset the Logback logging system
-        LogbackTestHelpers.resetLogback(logbackConfigFilePath);
+        if (isBlank(logbackConfigFilePath)) {
+            LogbackTestHelpers.resetLogback();
+        } else {
+            LogbackTestHelpers.resetLogback(logbackConfigFilePath);
+        }
 
         // Try again and return whatever we get. It should not be null after resetting, unless
         // the reset failed, or the appender was not configured correctly.

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -34,6 +34,7 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
     private final String appenderName;
 
     // Use the default Logback test configuration file as our default value.
+    @Getter
     private String logbackConfigFilePath = ClassicConstants.TEST_AUTOCONFIG_FILE;
 
     @Getter

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -1,13 +1,13 @@
 package org.kiwiproject.test.logback;
 
 import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -176,15 +176,16 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
         System.out.println("You can customize the logging configuration using #withLogbackConfigFilePath");
 
         // Reset the Logback logging system
-        if (isBlank(logbackConfigFilePath)) {
-            LogbackTestHelpers.resetLogback();
-        } else {
-            LogbackTestHelpers.resetLogback(logbackConfigFilePath);
-        }
+        getLogbackTestHelper().resetLogbackWithDefaultOrConfig(logbackConfigFilePath);
 
         // Try again and return whatever we get. It should not be null after resetting, unless
         // the reset failed, or the appender was not configured correctly.
         return logbackLogger.getAppender(appenderName);
+    }
+
+    @VisibleForTesting
+    protected LogbackTestHelper getLogbackTestHelper() {
+        return new LogbackTestHelper();
     }
 
     /**

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -5,13 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.joran.spi.JoranException;
 import com.google.common.annotations.Beta;
-import com.google.common.io.Resources;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -153,7 +149,7 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
      * @param context the current extension context; never {@code null}
      */
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
+    public void beforeEach(ExtensionContext context) {
         var logbackLogger = (Logger) LoggerFactory.getLogger(loggerClass);
         var rawAppender = getAppender(logbackLogger);
 
@@ -166,7 +162,7 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
 
     @Nullable
     @SuppressWarnings("java:S106")
-    private Appender<ILoggingEvent> getAppender(Logger logbackLogger) throws JoranException {
+    private Appender<ILoggingEvent> getAppender(Logger logbackLogger) {
         var rawAppender = logbackLogger.getAppender(appenderName);
 
         if (nonNull(rawAppender)) {
@@ -180,14 +176,7 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
         System.out.println("You can customize the logging configuration using #withLogbackConfigFilePath");
 
         // Reset the Logback logging system
-        var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        loggerContext.stop();
-
-        var joranConfigurator = new JoranConfigurator();
-        joranConfigurator.setContext(loggerContext);
-        var logbackConfigUrl = Resources.getResource(logbackConfigFilePath);
-        joranConfigurator.doConfigure(logbackConfigUrl);
-        loggerContext.start();
+        LogbackTestHelpers.resetLogback(logbackConfigFilePath);
 
         // Try again and return whatever we get. It should not be null after resetting, unless
         // the reset failed, or the appender was not configured correctly.

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -161,8 +161,9 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
     }
 
     @Nullable
+    @VisibleForTesting
     @SuppressWarnings("java:S106")
-    private Appender<ILoggingEvent> getAppender(Logger logbackLogger) {
+    Appender<ILoggingEvent> getAppender(Logger logbackLogger) {
         var rawAppender = logbackLogger.getAppender(appenderName);
 
         if (nonNull(rawAppender)) {

--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelper.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelper.java
@@ -1,0 +1,46 @@
+package org.kiwiproject.test.logback;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Provides utilities for Logback-related functionality.
+ * <p>
+ * This is an instance-based utility class, and is mainly useful if you need to mock
+ * its behavior. By default, it delegates to {@link LogbackTestHelpers} for methods
+ * that have the same signature.
+ */
+public class LogbackTestHelper {
+
+    /**
+     * Resets Logback using either the given config file, or uses the defaults
+     * as provided by {@link LogbackTestHelpers#resetLogback()}.
+     *
+     * @param logbackConfigFile the Logback config file to use, or null
+     */
+    public void resetLogbackWithDefaultOrConfig(@Nullable String logbackConfigFile) {
+        if (isBlank(logbackConfigFile)) {
+            resetLogback();
+        } else {
+            resetLogback(logbackConfigFile);
+        }
+    }
+
+    /**
+     * Delegates to {@link LogbackTestHelpers#resetLogback()}.
+     */
+    public void resetLogback() {
+        LogbackTestHelpers.resetLogback();
+    }
+
+    /**
+     * Delegates to {@link LogbackTestHelpers#resetLogback(String, String...)}.
+     *
+     * @param logbackConfigFile   the location of the custom Logback configuration file
+     * @param fallbackConfigFiles additional locations to check for Logback configuration files
+     */
+    public void resetLogback(String logbackConfigFile, String... fallbackConfigFiles) {
+        LogbackTestHelpers.resetLogback(logbackConfigFile, fallbackConfigFiles);
+    }
+}

--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
@@ -40,9 +40,11 @@ public class LogbackTestHelpers {
     }
 
     /**
-     * Reset the Logback logging system using the given configuration file or fallback configuration files.
+     * Reset the Logback logging system using the given configuration file.
+     * If the primary file does not exist, use the first fallback configuration
+     * file that exists. If the reset fails, an exception is thrown immediately.
      * <p>
-     * The fallback configurations are tried in the order they are provided.
+     * The fallback configurations are searched in the order they are provided.
      *
      * @param logbackConfigFile the location of the custom Logback configuration file
      * @param fallbackConfigFiles additional locations to check for Logback configuration files

--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
@@ -55,12 +55,13 @@ public class LogbackTestHelpers {
         checkArgument(isNoneBlank(fallbackConfigFiles), "fallbackConfigFiles must not contain blank locations");
 
         try {
+            var logbackConfigUrl = getFirstLogbackConfigOrThrow(logbackConfigFile, fallbackConfigFiles);
+
             var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
             loggerContext.stop();
 
             var joranConfigurator = new JoranConfigurator();
             joranConfigurator.setContext(loggerContext);
-            var logbackConfigUrl = getFirstLogbackConfigOrThrow(logbackConfigFile, fallbackConfigFiles);
             joranConfigurator.doConfigure(logbackConfigUrl);
             loggerContext.start();
         } catch (JoranException e) {

--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
@@ -1,14 +1,11 @@
 package org.kiwiproject.test.logback;
 
-import com.google.common.io.Resources;
-
-import lombok.experimental.UtilityClass;
-
 import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
-
+import com.google.common.io.Resources;
+import lombok.experimental.UtilityClass;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
@@ -1,12 +1,23 @@
 package org.kiwiproject.test.logback;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import com.google.common.io.Resources;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.collections4.ListUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Static test utilities that provide Logback-related functionality.
@@ -16,32 +27,67 @@ public class LogbackTestHelpers {
 
     /**
      * Reset the Logback logging system using the default test configuration file ({@code logback-test.xml}).
+     * If that doesn't exist, try to fall back to the default configuration file ({@code logback.xml}).
+     * <p>
+     * If you need a custom location (or locations), use {@link #resetLogback(String, String...)}.
      *
-     * @see ClassicConstants#TEST_AUTOCONFIG_FILE
      * @throws UncheckedJoranException if an error occurs resetting Logback
+     * @see ClassicConstants#TEST_AUTOCONFIG_FILE
+     * @see ClassicConstants#AUTOCONFIG_FILE
      */
     public static void resetLogback() {
-        resetLogback(ClassicConstants.TEST_AUTOCONFIG_FILE);
+        resetLogback(ClassicConstants.TEST_AUTOCONFIG_FILE, ClassicConstants.AUTOCONFIG_FILE);
     }
 
     /**
-     * Reset the Logback logging system using the given configuration file.
+     * Reset the Logback logging system using the given configuration file or fallback configuration files.
+     * <p>
+     * The fallback configurations are tried in the order they are provided.
      *
-     * @param logbackConfigFilePath the location of the custom Logback configuration file
+     * @param logbackConfigFile the location of the custom Logback configuration file
+     * @param fallbackConfigFiles additional locations to check for Logback configuration files
      * @throws UncheckedJoranException if an error occurs resetting Logback
+     * @throws IllegalArgumentException if none of the Logback configuration files exist
      */
-    public static void resetLogback(String logbackConfigFilePath) {
+    public static void resetLogback(String logbackConfigFile, String... fallbackConfigFiles) {
+        checkArgumentNotBlank(logbackConfigFile, "logbackConfigFile must not be blank");
+        checkArgumentNotNull(fallbackConfigFiles, "fallback locations vararg parameter must not be null");
+        checkArgument(isNoneBlank(fallbackConfigFiles), "fallbackConfigFiles must not contain blank locations");
+
         try {
             var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
             loggerContext.stop();
 
             var joranConfigurator = new JoranConfigurator();
             joranConfigurator.setContext(loggerContext);
-            var logbackConfigUrl = Resources.getResource(logbackConfigFilePath);
+            var logbackConfigUrl = getFirstLogbackConfigOrThrow(logbackConfigFile, fallbackConfigFiles);
             joranConfigurator.doConfigure(logbackConfigUrl);
             loggerContext.start();
         } catch (JoranException e) {
             throw new UncheckedJoranException(e);
+        }
+    }
+
+    private static URL getFirstLogbackConfigOrThrow(String logbackConfigFilePath, String... fallbackConfigFilePaths) {
+        var allConfigs = ListUtils.union(
+                List.of(logbackConfigFilePath),
+                List.of(fallbackConfigFilePaths)
+        );
+
+        return allConfigs.stream()
+                .map(LogbackTestHelpers::getResourceOrNull)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalArgumentException("Did not find any of the Logback configurations: " + allConfigs));
+    }
+
+    @Nullable
+    private static URL getResourceOrNull(String resourceName) {
+        try {
+            return Resources.getResource(resourceName);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 }

--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
@@ -1,0 +1,50 @@
+package org.kiwiproject.test.logback;
+
+import com.google.common.io.Resources;
+
+import lombok.experimental.UtilityClass;
+
+import ch.qos.logback.classic.ClassicConstants;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import org.slf4j.LoggerFactory;
+
+/**
+ * Static test utilities that provide Logback-related functionality.
+ */
+@UtilityClass
+public class LogbackTestHelpers {
+
+    /**
+     * Reset the Logback logging system using the default test configuration file ({@code logback-test.xml}).
+     *
+     * @see ClassicConstants#TEST_AUTOCONFIG_FILE
+     * @throws UncheckedJoranException if an error occurs resetting Logback
+     */
+    public static void resetLogback() {
+        resetLogback(ClassicConstants.TEST_AUTOCONFIG_FILE);
+    }
+
+    /**
+     * Reset the Logback logging system using the given configuration file.
+     *
+     * @param logbackConfigFilePath the location of the custom Logback configuration file
+     * @throws UncheckedJoranException if an error occurs resetting Logback
+     */
+    public static void resetLogback(String logbackConfigFilePath) {
+        try {
+            var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            loggerContext.stop();
+
+            var joranConfigurator = new JoranConfigurator();
+            joranConfigurator.setContext(loggerContext);
+            var logbackConfigUrl = Resources.getResource(logbackConfigFilePath);
+            joranConfigurator.doConfigure(logbackConfigUrl);
+            loggerContext.start();
+        } catch (JoranException e) {
+            throw new UncheckedJoranException(e);
+        }
+    }
+}

--- a/src/main/java/org/kiwiproject/test/logback/UncheckedJoranException.java
+++ b/src/main/java/org/kiwiproject/test/logback/UncheckedJoranException.java
@@ -1,0 +1,42 @@
+package org.kiwiproject.test.logback;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import ch.qos.logback.core.joran.spi.JoranException;
+
+/**
+ * Wraps a {@link JoranException} with an unchecked exception.
+ */
+public class UncheckedJoranException extends RuntimeException {
+
+    /**
+     * Construct an instance.
+     *
+     * @param message the message, which can be null
+     * @param cause   the cause, which cannot be null
+     * @throws IllegalArgumentException if cause is null
+     */
+    public UncheckedJoranException(String message, JoranException cause) {
+        super(message, requireNotNull(cause));
+    }
+
+    /**
+     * Construct an instance.
+     *
+     * @param cause the cause, which cannot be null
+     * @throws IllegalArgumentException if cause is null
+     */
+    public UncheckedJoranException(JoranException cause) {
+        super(requireNotNull(cause));
+    }
+
+    /**
+     * Returns the cause of this exception.
+     *
+     * @return the {@link JoranException} which is the cause of this exception
+     */
+    @Override
+    public JoranException getCause() {
+        return (JoranException) super.getCause();
+    }
+}

--- a/src/main/java/org/kiwiproject/test/logback/UncheckedJoranException.java
+++ b/src/main/java/org/kiwiproject/test/logback/UncheckedJoranException.java
@@ -36,7 +36,7 @@ public class UncheckedJoranException extends RuntimeException {
      * @return the {@link JoranException} which is the cause of this exception
      */
     @Override
-    public JoranException getCause() {
+    public synchronized JoranException getCause() {
         return (JoranException) super.getCause();
     }
 }

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
@@ -27,12 +27,14 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 
 import java.util.List;
 
 @DisplayName("DropwizardAppTests")
 @ExtendWith(SoftAssertionsExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
+@ExtendWith(ResetLogbackLoggingExtension.class)
 class DropwizardAppTestsTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
@@ -18,9 +18,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 
 @DisplayName("PostgresAppTestExtension: ConfigOverrides")
+@ExtendWith(ResetLogbackLoggingExtension.class)
 class PostgresAppTestExtensionConfigOverridesTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
@@ -28,7 +28,7 @@ class PostgresAppTestExtensionConfigOverridesTest {
 
     @Getter
     @Setter
-    static class Config extends Configuration {
+    public static class Config extends Configuration {
         @Valid
         @NotNull
         @JsonProperty("database")

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
@@ -29,7 +29,7 @@ class PostgresAppTestExtensionCustomPropertyTest {
 
     @Getter
     @Setter
-    static class Config extends Configuration {
+    public static class Config extends Configuration {
         @Valid
         @NotNull
         @JsonProperty("db")

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
@@ -16,12 +16,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 
 /**
  * Tests that we can specify a custom name in the configuration for the DataSourceFactory.
  */
 @DisplayName("PostgresAppTestExtension (custom DataSourceFactory property")
+@ExtendWith(ResetLogbackLoggingExtension.class)
 class PostgresAppTestExtensionCustomPropertyTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -16,9 +16,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 
 @DisplayName("PostgresAppTestExtension")
+@ExtendWith(ResetLogbackLoggingExtension.class)
 class PostgresAppTestExtensionTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -26,7 +26,7 @@ class PostgresAppTestExtensionTest {
 
     @Getter
     @Setter
-    static class Config extends Configuration {
+    public static class Config extends Configuration {
         @Valid
         @NotNull
         @JsonProperty("database")

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtensionTest.java
@@ -110,7 +110,7 @@ class Jdbi3DaoExtensionTest {
     }
 
     @Value
-    private static class TestTableValue {
+    public static class TestTableValue {
         String col1;
         int col2;
     }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
@@ -1,0 +1,36 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.ClassicConstants;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResetLogbackLoggingExtension")
+class ResetLogbackLoggingExtensionTest {
+
+    @Test
+    void shouldConstructWithLogbackTestFileAsDefaultConfigLocation() {
+        var extension = new ResetLogbackLoggingExtension();
+        assertThat(extension.getLogbackConfigFilePath())
+                .isEqualTo(ClassicConstants.TEST_AUTOCONFIG_FILE);
+    }
+
+    @Test
+    void shouldBuildWithLogbackTestFileAsDefaultConfigLocation() {
+        var extension = ResetLogbackLoggingExtension.builder().build();
+        assertThat(extension.getLogbackConfigFilePath())
+                .isEqualTo(ClassicConstants.TEST_AUTOCONFIG_FILE);
+    }
+
+    @Test
+    void shouldAllowCustomConfigLocation() {
+        var customLocation = "acme-test-logback.xml";
+
+        var extension = ResetLogbackLoggingExtension.builder()
+                .logbackConfigFilePath(customLocation)
+                .build();
+
+        assertThat(extension.getLogbackConfigFilePath()).isEqualTo(customLocation);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
@@ -2,7 +2,6 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ch.qos.logback.classic.ClassicConstants;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,17 +9,15 @@ import org.junit.jupiter.api.Test;
 class ResetLogbackLoggingExtensionTest {
 
     @Test
-    void shouldConstructWithLogbackTestFileAsDefaultConfigLocation() {
+    void shouldConstructWithNullAsDefaultConfigLocation() {
         var extension = new ResetLogbackLoggingExtension();
-        assertThat(extension.getLogbackConfigFilePath())
-                .isEqualTo(ClassicConstants.TEST_AUTOCONFIG_FILE);
+        assertThat(extension.getLogbackConfigFilePath()).isNull();
     }
 
     @Test
-    void shouldBuildWithLogbackTestFileAsDefaultConfigLocation() {
+    void shouldBuildWithNullAsDefaultConfigLocation() {
         var extension = ResetLogbackLoggingExtension.builder().build();
-        assertThat(extension.getLogbackConfigFilePath())
-                .isEqualTo(ClassicConstants.TEST_AUTOCONFIG_FILE);
+        assertThat(extension.getLogbackConfigFilePath()).isNull();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
@@ -2,7 +2,6 @@ package org.kiwiproject.test.logback;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ch.qos.logback.classic.ClassicConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,7 @@ class InMemoryAppenderExtensionTest {
     @Test
     void shouldUseLogbackTestFileAsDefaultConfigLocation() {
         var extension = new InMemoryAppenderExtension(InMemoryAppenderExtensionTest.class);
-        assertThat(extension.getLogbackConfigFilePath())
-                .isEqualTo(ClassicConstants.TEST_AUTOCONFIG_FILE);
+        assertThat(extension.getLogbackConfigFilePath()).isNull();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
@@ -35,6 +35,18 @@ class InMemoryAppenderExtensionTest {
     }
 
     @ClearBoxTest
+    void shouldReturnNewLogbackTestHelperInstances() {
+        var extension = new InMemoryAppenderExtension(InMemoryAppenderExtensionTest.class);
+
+        var helper1 = extension.getLogbackTestHelper();
+        var helper2 = extension.getLogbackTestHelper();
+        var helper3 = extension.getLogbackTestHelper();
+
+        assertThat(helper1).isNotSameAs(helper2);
+        assertThat(helper2).isNotSameAs(helper3);
+    }
+
+    @ClearBoxTest
     void shouldGetAppenderWhenExists() {
         var logbackLogger = mock(Logger.class);
         var appender = new InMemoryAppender();

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
@@ -1,10 +1,19 @@
 package org.kiwiproject.test.logback;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
 
 @DisplayName("InMemoryAppenderExtension")
 @Slf4j
@@ -23,5 +32,56 @@ class InMemoryAppenderExtensionTest {
                 .withLogbackConfigFilePath(customLocation);
 
         assertThat(extension.getLogbackConfigFilePath()).isEqualTo(customLocation);
+    }
+
+    @ClearBoxTest
+    void shouldGetAppenderWhenExists() {
+        var logbackLogger = mock(Logger.class);
+        var appender = new InMemoryAppender();
+        when(logbackLogger.getAppender(anyString())).thenReturn(appender);
+
+        var extension = new InMemoryAppenderExtension(InMemoryAppenderExtensionTest.class);
+
+        var returnedAppender = extension.getAppender(logbackLogger);
+        assertThat(returnedAppender).isSameAs(appender);
+
+        verify(logbackLogger, only()).getAppender(expectedAppenderName());
+    }
+
+    private static String expectedAppenderName() {
+        return InMemoryAppenderExtensionTest.class.getSimpleName() + "Appender";
+    }
+
+    @ClearBoxTest
+    void shouldResetLogbackWhenAppenderDoesNotExist() {
+        var logbackLogger = mock(Logger.class);
+        var appender = new InMemoryAppender();
+
+        // Simulate initially not getting the appender
+        // then getting an appender (once Logback has been reset)
+        when(logbackLogger.getAppender(anyString()))
+                .thenReturn(null)
+                .thenReturn(appender);
+
+        var logbackTestHelper = mock(LogbackTestHelper.class);
+
+        var appenderName = "MyAppender";
+        var extension = new InMemoryAppenderExtension(InMemoryAppenderExtensionTest.class, appenderName) {
+            @Override
+            protected LogbackTestHelper getLogbackTestHelper() {
+                return logbackTestHelper;
+            }
+        };
+
+        var customConfig = "acme-logback-test.xml";
+        extension.withLogbackConfigFilePath(customConfig);
+
+        var returnedAppender = extension.getAppender(logbackLogger);
+        assertThat(returnedAppender).isSameAs(appender);
+
+        verify(logbackLogger, times(2)).getAppender(appenderName);
+        verifyNoMoreInteractions(logbackLogger);
+
+        verify(logbackTestHelper, only()).resetLogbackWithDefaultOrConfig(customConfig);
     }
 }

--- a/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/InMemoryAppenderExtensionTest.java
@@ -1,0 +1,29 @@
+package org.kiwiproject.test.logback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.ClassicConstants;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("InMemoryAppenderExtension")
+@Slf4j
+class InMemoryAppenderExtensionTest {
+
+    @Test
+    void shouldUseLogbackTestFileAsDefaultConfigLocation() {
+        var extension = new InMemoryAppenderExtension(InMemoryAppenderExtensionTest.class);
+        assertThat(extension.getLogbackConfigFilePath())
+                .isEqualTo(ClassicConstants.TEST_AUTOCONFIG_FILE);
+    }
+
+    @Test
+    void shouldAcceptCustomConfigLocation() {
+        var customLocation = "acme-test-logback.xml";
+        var extension = new InMemoryAppenderExtension(InMemoryAppenderExtensionTest.class)
+                .withLogbackConfigFilePath(customLocation);
+
+        assertThat(extension.getLogbackConfigFilePath()).isEqualTo(customLocation);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelperTest.java
@@ -1,0 +1,42 @@
+package org.kiwiproject.test.logback;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.kiwiproject.test.junit.jupiter.params.provider.MinimalBlankStringSource;
+
+@DisplayName("Logback")
+class LogbackTestHelperTest {
+
+    private LogbackTestHelper helper;
+
+    @BeforeEach
+    void setUp() {
+        helper = spy(new LogbackTestHelper());
+
+        doNothing().when(helper).resetLogback();
+        doNothing().when(helper).resetLogback(anyString());
+    }
+
+    @Test
+    void shouldResetLogbackWithCustomConfiguration() {
+        var customConfig = "test-acme-logback.xml";
+        helper.resetLogbackWithDefaultOrConfig(customConfig);
+
+        verify(helper).resetLogback(customConfig);
+    }
+
+    @ParameterizedTest
+    @MinimalBlankStringSource
+    void shouldUseDefaultWhenCustomConfigurationIsBlank(String configFile) {
+        helper.resetLogbackWithDefaultOrConfig(configFile);
+
+        verify(helper).resetLogback();
+    }
+}

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelperTest.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.test.logback;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
@@ -38,5 +39,16 @@ class LogbackTestHelperTest {
         helper.resetLogbackWithDefaultOrConfig(configFile);
 
         verify(helper).resetLogback();
+    }
+
+    @Test
+    void shouldDelegateToLogbackTestHelpersWithFallback() {
+        // Verify the delegation without actually resetting Logback
+        // by passing in config files that don't exist.
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() ->
+                        new LogbackTestHelper().resetLogback("acme-test-logback.xml", "acme-logback.xml"))
+                .withMessage("Did not find any of the Logback configurations: [acme-test-logback.xml, acme-logback.xml]");
     }
 }

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
@@ -4,15 +4,14 @@ import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import ch.qos.logback.classic.Logger;
 import com.codahale.metrics.health.HealthCheck;
-
 import io.dropwizard.core.Application;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,8 +22,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 import org.slf4j.LoggerFactory;
-
-import ch.qos.logback.classic.Logger;
 
 /**
  * This integration test uses DropwizardAppExtension which resets Logback when it
@@ -60,12 +57,12 @@ public class LogbackTestHelpersIntegrationTest {
     public static class MyApp extends Application<MyConfig> {
 
         @Override
-        public void run(MyConfig config, Environment environment) throws Exception {
+        public void run(MyConfig config, Environment environment) {
             // does nothing at all
 
             environment.healthChecks().register("noop", new HealthCheck() {
                 @Override
-                protected Result check() throws Exception {
+                protected Result check() {
                     return Result.healthy("Everything's fine here, how are you?");
                 }
             });

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * This integration test uses DropwizardAppExtension which resets Logback when it
  * starts the test application class. It first verifies that there is no appender
  * for this class' Logger, and then uses {@link LogbackTestHelpers#resetLogback()}
- * to reset Loback to the default logging configuration. Finally, it ensures that
+ * to reset Logback to the default logging configuration. Finally, it ensures that
  * the InMemoryAppender was reset and that it receives the expected messages.
  * <p>
  * The tests are designed to execute in a specific order and use Jupiter's
@@ -40,14 +40,14 @@ import org.slf4j.LoggerFactory;
  * {@link LogbackTestHelpers}, it might not work if there is actually a bug and
  * is therefore a bit circular. But, since it uses {@link LogbackTestHelpers#resetLogback(String)}
  * with {@link ch.qos.logback.classic.ClassicConstants#TEST_AUTOCONFIG_FILE} as its
- * argument, instead of the no-arg method, it is slightly different than here.
+ * argument, instead of the no-arg method, it is slightly different from here.
  */
 @DisplayName("LogbackTestHelpers (Integration Test)")
 @ExtendWith(DropwizardExtensionsSupport.class)
 @ExtendWith(ResetLogbackLoggingExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Slf4j
-public class LogbackTestHelpersIntegrationTest {
+class LogbackTestHelpersIntegrationTest {
 
     private static final String APPENDER_NAME = "LogbackTestHelpersIntegrationTestAppender";
 
@@ -69,6 +69,7 @@ public class LogbackTestHelpersIntegrationTest {
         }
     }
 
+    @SuppressWarnings("unused")
     static final DropwizardAppExtension<MyConfig> APP_EXTENSION = new DropwizardAppExtension<>(MyApp.class);
 
     private Logger logbackLogger;

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
@@ -38,9 +38,7 @@ import org.slf4j.LoggerFactory;
  * In case of failure, this test uses the ResetLogbackLoggingExtension to restore
  * the Logback logging configuration. However, since that extension simply uses
  * {@link LogbackTestHelpers}, it might not work if there is actually a bug and
- * is therefore a bit circular. But, since it uses {@link LogbackTestHelpers#resetLogback(String)}
- * with {@link ch.qos.logback.classic.ClassicConstants#TEST_AUTOCONFIG_FILE} as its
- * argument, instead of the no-arg method, it is slightly different from here.
+ * is therefore a bit circular.
  */
 @DisplayName("LogbackTestHelpers (Integration Test)")
 @ExtendWith(DropwizardExtensionsSupport.class)

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
@@ -1,0 +1,165 @@
+package org.kiwiproject.test.logback;
+
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import io.dropwizard.core.Application;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+/**
+ * This integration test uses DropwizardAppExtension which resets Logback when it
+ * starts the test application class. It first verifies that there is no appender
+ * for this class' Logger, and then uses {@link LogbackTestHelpers#resetLogback()}
+ * to reset Loback to the default logging configuration. Finally, it ensures that
+ * the InMemoryAppender was reset and that it receives the expected messages.
+ * <p>
+ * The tests are designed to execute in a specific order and use Jupiter's
+ * method ordering feature. The first test executes after DropwizardAppExtension
+ * has reset Logback, so we expect the appender to be null. That test resets
+ * Logback, after which all subsequent tests should get a non-null appender.
+ * <p>
+ * In case of failure, this test uses the ResetLogbackLoggingExtension to restore
+ * the Logback logging configuration. However, since that extension simply uses
+ * {@link LogbackTestHelpers}, it might not work if there is actually a bug and
+ * is therefore a bit circular. But, since it uses {@link LogbackTestHelpers#resetLogback(String)}
+ * with {@link ch.qos.logback.classic.ClassicConstants#TEST_AUTOCONFIG_FILE} as its
+ * argument, instead of the no-arg method, it is slightly different than here.
+ */
+@DisplayName("LogbackTestHelpers (Integration Test)")
+@ExtendWith(DropwizardExtensionsSupport.class)
+@ExtendWith(ResetLogbackLoggingExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Slf4j
+public class LogbackTestHelpersIntegrationTest {
+
+    private static final String APPENDER_NAME = "LogbackTestHelpersIntegrationTestAppender";
+
+    public static class MyConfig extends Configuration {
+    }
+
+    public static class MyApp extends Application<MyConfig> {
+
+        @Override
+        public void run(MyConfig config, Environment environment) throws Exception {
+            // does nothing at all
+
+            environment.healthChecks().register("noop", new HealthCheck() {
+                @Override
+                protected Result check() throws Exception {
+                    return Result.healthy("Everything's fine here, how are you?");
+                }
+            });
+        }
+    }
+
+    static final DropwizardAppExtension<MyConfig> APP_EXTENSION = new DropwizardAppExtension<>(MyApp.class);
+
+    private Logger logbackLogger;
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        logbackLogger = getLogbackLogger();
+        appender = getAppender();
+
+        assertThat(logbackLogger)
+                .describedAs("Getting the logger as a Logback Logger should always return the same Logger instance")
+                .isSameAs(LOG);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // This must re-fetch the appender, since the instance field can be null (for the first test)
+        var freshAppender = getAppender();
+        if (nonNull(freshAppender)) {
+            freshAppender.clearEvents();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void shouldResetDefaultLoggingConfiguration() {
+        assertThat(appender)
+                .describedAs("appender should be null; DropwizardAppExtension is expected to have reset Logback")
+                .isNull();
+
+        assertThatCode(() -> {
+            LOG.debug("message 1");
+            LOG.info("message 2");
+            LOG.warn("message 3");
+            LOG.error("message 4");
+        })
+        .describedAs("We should still be able to log things (they just won't go anywhere)")
+        .doesNotThrowAnyException();
+
+        LogbackTestHelpers.resetLogback();
+
+        LOG.trace("message 5");
+        LOG.debug("message 6");
+        LOG.info("message 7");
+        LOG.warn("message 8");
+        LOG.error("message 9");
+
+        var resetAppender = getAppender();
+        assertThat(resetAppender).isNotNull();
+
+        assertThat(resetAppender.orderedEventMessages()).containsExactly(
+            "message 6","message 7","message 8", "message 9");
+    }
+
+    @Test
+    @Order(2)
+    void shouldHaveAppenderOnceReset() {
+        assertThat(appender)
+                .describedAs("appender should not be null; previous test should have reset it")
+                .isNotNull();
+
+        LOG.trace("message 0");
+        LOG.debug("message A");
+        LOG.info("message B");
+        LOG.warn("message C");
+
+        assertThat(appender.orderedEventMessages()).containsExactly(
+            "message A", "message B", "message C");
+    }
+
+    @Test
+    @Order(3)
+    void shouldStillHaveAppender() {
+        assertThat(appender)
+                .describedAs("appender should not be null; first test should have reset it")
+                .isNotNull();
+
+        LOG.debug("message Z");
+
+        assertThat(appender.orderedEventMessages()).containsExactly("message Z");
+    }
+
+    private static Logger getLogbackLogger() {
+        return (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LogbackTestHelpersIntegrationTest.class);
+    }
+
+    private InMemoryAppender getAppender() {
+        return (InMemoryAppender) logbackLogger.getAppender(APPENDER_NAME);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersTest.java
@@ -5,9 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import ch.qos.logback.core.joran.spi.JoranException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
+import org.kiwiproject.test.junit.jupiter.params.provider.MinimalBlankStringSource;
 
 /**
  * Unit test for {@link LogbackTestHelpers}. This mainly tests invalid arguments
@@ -18,16 +21,52 @@ import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 @ExtendWith(ResetLogbackLoggingExtension.class)
 class LogbackTestHelpersTest {
 
-    @Test
-    void shouldThrowIllegalArgument_WhenInvalidLogbackConfigPath() {
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> LogbackTestHelpers.resetLogback("dne.xml"));
+    @Nested
+    class ThrowsIllegalArgumentException {
+
+        @Test
+        void whenInvalidLogbackConfigPath() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> LogbackTestHelpers.resetLogback("dne.xml"))
+                    .withMessage("Did not find any of the Logback configurations: [dne.xml]");
+        }
+
+        @Test
+        void whenInvalidLogbackConfigPaths() {
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                            LogbackTestHelpers.resetLogback("dne1.xml", "dne2.xml", "dne3.xml"))
+                    .withMessage("Did not find any of the Logback configurations: [dne1.xml, dne2.xml, dne3.xml]");
+        }
+
+        @ParameterizedTest
+        @MinimalBlankStringSource
+        void whenGivenBlankConfigLocation(String location) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> LogbackTestHelpers.resetLogback(location))
+                    .withMessage("logbackConfigFile must not be blank");
+        }
+
+        @Test
+        void whenExplicitNullFallbackLocationsIsGiven() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> LogbackTestHelpers.resetLogback("acme-logback.xml", (String[]) null))
+                    .withMessage("fallback locations vararg parameter must not be null");
+        }
+
+        @ParameterizedTest
+        @MinimalBlankStringSource
+        void whenFallbackLocationIsBlank(String fallbackLocation) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> LogbackTestHelpers.resetLogback("acme-test-logback.xml", fallbackLocation))
+                    .withMessage("fallbackConfigFiles must not contain blank locations");
+        }
     }
 
     @Test
     void shouldThrowUncheckedJoranException_WhenInvalidLogbackConfig() {
         assertThatExceptionOfType(UncheckedJoranException.class)
-                .isThrownBy(() -> LogbackTestHelpers.resetLogback("LogbackTestHelpersTest/invalid-logback-test.xml"))
+                .isThrownBy(() ->
+                        LogbackTestHelpers.resetLogback("LogbackTestHelpersTest/invalid-logback-test.xml"))
                 .withCauseExactlyInstanceOf(JoranException.class);
     }
 }

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersTest.java
@@ -1,0 +1,34 @@
+package org.kiwiproject.test.logback;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
+
+import ch.qos.logback.core.joran.spi.JoranException;
+
+/**
+ * Unit test for {@link LogbackTestHelpers}. This mainly tests invalid arguments
+ * and invalid Logback configuration. {@link LogbackTestHelpersIntegrationTest}
+ * performs a full integration test of the reset behavior.
+ */
+@DisplayName("LogbackTestHelpers")
+@ExtendWith(ResetLogbackLoggingExtension.class)
+public class LogbackTestHelpersTest {
+
+    @Test
+    void shouldThrowIllegalArgument_WhenInvalidLogbackConfigPath() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> LogbackTestHelpers.resetLogback("dne.xml"));
+    }
+
+    @Test
+    void shouldThrowUncheckedJoranException_WhenInvalidLogbackConfig() {
+        assertThatExceptionOfType(UncheckedJoranException.class)
+                .isThrownBy(() -> LogbackTestHelpers.resetLogback("LogbackTestHelpersTest/invalid-logback-test.xml"))
+                .withCauseExactlyInstanceOf(JoranException.class);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersTest.java
@@ -3,12 +3,11 @@ package org.kiwiproject.test.logback;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import ch.qos.logback.core.joran.spi.JoranException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
-
-import ch.qos.logback.core.joran.spi.JoranException;
 
 /**
  * Unit test for {@link LogbackTestHelpers}. This mainly tests invalid arguments
@@ -17,7 +16,7 @@ import ch.qos.logback.core.joran.spi.JoranException;
  */
 @DisplayName("LogbackTestHelpers")
 @ExtendWith(ResetLogbackLoggingExtension.class)
-public class LogbackTestHelpersTest {
+class LogbackTestHelpersTest {
 
     @Test
     void shouldThrowIllegalArgument_WhenInvalidLogbackConfigPath() {

--- a/src/test/java/org/kiwiproject/test/logback/UncheckedJoranExceptionTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/UncheckedJoranExceptionTest.java
@@ -1,0 +1,32 @@
+package org.kiwiproject.test.logback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ch.qos.logback.core.joran.spi.JoranException;
+
+@DisplayName("UncheckedJoranException")
+class UncheckedJoranExceptionTest {
+
+    @Test
+    void shouldRequireCause() {
+        assertAll(
+            () -> assertThatIllegalArgumentException().isThrownBy(() -> new UncheckedJoranException("oops", null)),
+            () -> assertThatIllegalArgumentException().isThrownBy(() -> new UncheckedJoranException(null))
+        );
+    }
+
+    @Test
+    void shouldSetCause() {
+        var joranException = new JoranException("Invalid XML");
+
+        assertAll(
+            () -> assertThat(new UncheckedJoranException("oops", joranException)).hasCause(joranException),
+            () -> assertThat(new UncheckedJoranException(joranException)).hasCause(joranException)
+        );
+    }
+}

--- a/src/test/java/org/kiwiproject/test/logback/UncheckedJoranExceptionTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/UncheckedJoranExceptionTest.java
@@ -4,14 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import ch.qos.logback.core.joran.spi.JoranException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import ch.qos.logback.core.joran.spi.JoranException;
 
 @DisplayName("UncheckedJoranException")
 class UncheckedJoranExceptionTest {
 
+    @SuppressWarnings("ThrowableNotThrown")
     @Test
     void shouldRequireCause() {
         assertAll(

--- a/src/test/resources/LogbackTestHelpersTest/invalid-logback-test.xml
+++ b/src/test/resources/LogbackTestHelpersTest/invalid-logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Intentionally cause XML parsing to fail -->
+    <logger name="org.kiwiproject.test" level="TRACE"
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -26,6 +26,14 @@
         <appender-ref ref="InMemoryAppenderTestAppender"/>
     </logger>
 
+    <!-- This is required for LogbackTestHelpersIntegrationTest -->
+    <appender name="LogbackTestHelpersIntegrationTestAppender" class="org.kiwiproject.test.logback.InMemoryAppender"/>
+
+    <!-- This is required for LogbackTestHelpersIntegrationTest -->
+    <logger name="org.kiwiproject.test.logback.LogbackTestHelpersIntegrationTest" level="DEBUG">
+        <appender-ref ref="LogbackTestHelpersIntegrationTestAppender"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
* Add LogbackTestHelpers utility class. This provides static utilities to reset Logback.
* Add LogbackTestHelper. This provides instance-based utilities to reset Logback.
* Add ResetLogbackLoggingExtension, a Jupiter extension to reset Logback after all tests have run.
* Add UncheckedJoranException, which wraps the checked Logback JoranException.
* Update several tests that use Dropwizard extensions to use ResetLogbackLoggingExtension to restore logging.

Closes #460
Closes #461