### PR TITLE
Fix javadoc in H2LiquibaseExtension

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtension.java
@@ -35,7 +35,7 @@ import javax.sql.DataSource;
  * <pre>
  * class SomeDatabaseTest {
  *
- *    {@literal @}H2LiquibaseExtension
+ *    {@literal @}RegisterExtension
  *     static final H2LiquibaseExtension H2_LIQUIBASE_EXTENSION =
  *             new H2LiquibaseExtension("test-migrations.xml");
  *


### PR DESCRIPTION
* The code example in the class-level javadoc should use the RegisterExtension annotation on the H2LiquibaseExtension field.