### PR TITLE
Sonar cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTests.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTests.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.test.dropwizard.app;
 
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
@@ -101,7 +101,7 @@ public class DropwizardAppTests {
                 .filter(InstanceBinding.class::isInstance)
                 .map(InstanceBinding.class::cast)
                 .map(InstanceBinding::getService)
-                .collect(toSet());
+                .collect(toUnmodifiableSet());
 
         return Sets.union(instances, wrappedResourceObjects);
     }

--- a/src/main/java/org/kiwiproject/test/validation/SoftValidationTestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/validation/SoftValidationTestAssertions.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.test.validation;
 
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
@@ -105,7 +105,7 @@ public class SoftValidationTestAssertions {
     public <T> Set<ConstraintViolation<T>> assertPropertiesEachHaveOneViolation(T object, String... propertyNames) {
         return Arrays.stream(propertyNames)
                 .flatMap(propertyName -> assertOnePropertyViolation(object, propertyName).stream())
-                .collect(toSet());
+                .collect(toUnmodifiableSet());
     }
 
     /**
@@ -137,7 +137,7 @@ public class SoftValidationTestAssertions {
     public <T> Set<ConstraintViolation<T>> assertPropertiesEachHaveNoViolations(T object, String... propertyNames) {
         return Arrays.stream(propertyNames)
                 .flatMap(propertyName -> assertNoPropertyViolations(object, propertyName).stream())
-                .collect(toSet());
+                .collect(toUnmodifiableSet());
     }
 
     /**

--- a/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
@@ -455,10 +455,10 @@ class HealthCheckResultAssertionsTest {
             @ValueSource(ints = { 1, 5, 10 })
             void shouldFail_WhenDetailsDoesNotHaveExpectedSize(int size) {
                 var details = createDetailsOfSize(size);
-                var healthCheck = MockHealthCheck.builder().details(details).build();
+                var mockHealthCheck = MockHealthCheck.builder().details(details).build();
 
                 var expectedSize = size + 1;
-                assertThatThrownBy(() -> assertThat(healthCheck).hasDetailsWithSize(expectedSize))
+                assertThatThrownBy(() -> assertThat(mockHealthCheck).hasDetailsWithSize(expectedSize))
                         .hasMessageContaining("Expected %d details, but found %d", expectedSize, size);
             }
 
@@ -515,10 +515,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldFail_WhenDetailsIsNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
 
                 assertThatThrownBy(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .isHealthy()
                                 .hasDetailsContainingKey("foo"))
                         .hasMessageContaining("Expected key not found in details");
@@ -548,10 +548,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldFail_WhenDetailsIsNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
 
                 assertThatThrownBy(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .isHealthy()
                                 .hasDetailsContainingKey("foo"))
                         .hasMessageContaining("Expected key not found in details");
@@ -587,10 +587,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldFail_WhenDetailsIsNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
 
                 assertThatThrownBy(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .isHealthy()
                                 .hasDetail("foo", "bar"))
                         .hasMessageContaining("Expected detail not found");
@@ -712,10 +712,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                var healthCheck = MockHealthCheck.builder().details(Map.of()).build();
+                var mockHealthCheck = MockHealthCheck.builder().details(Map.of()).build();
 
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .isHealthy()
                                 .hasEmptyDetails())
                         .doesNotThrowAnyException();
@@ -723,11 +723,11 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldFail_WhenDetailsAreNotEmpty() {
-                var healthCheck = MockHealthCheck.builder().details(Map.of("answer", 42)).build();
+                var mockHealthCheck = MockHealthCheck.builder().details(Map.of("answer", 42)).build();
 
 
                 assertThatThrownBy(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .isHealthy()
                                 .hasEmptyDetails())
                         .hasMessageContaining("Expected empty (non-null) details");
@@ -739,20 +739,20 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
 
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .hasNullDetails())
                         .doesNotThrowAnyException();
             }
 
             @Test
             void shouldFail_WhenDetailsAreNotNull() {
-                var healthCheck = MockHealthCheck.builder().detail("answer", 42).build();
+                var mockHealthCheck = MockHealthCheck.builder().detail("answer", 42).build();
 
                 assertThatThrownBy(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .hasNullDetails())
                         .hasMessageContaining("Expected null details");
             }
@@ -764,10 +764,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
 
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .isHealthy()
                                 .hasNullOrEmptyDetails())
                         .doesNotThrowAnyException();
@@ -775,10 +775,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                var healthCheck = newMockHealthCheckWithEmptyDetails();
+                var mockHealthCheck = newMockHealthCheckWithEmptyDetails();
 
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .isHealthy()
                                 .hasNullOrEmptyDetails())
                         .doesNotThrowAnyException();
@@ -786,10 +786,10 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldFail_WhenDetailsAreNotNullOrEmpty() {
-                var healthCheck = MockHealthCheck.builder().detail("answer", 42).build();
+                var mockHealthCheck = MockHealthCheck.builder().detail("answer", 42).build();
 
                 assertThatThrownBy(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .isHealthy()
                                 .hasNullOrEmptyDetails())
                         .hasMessageContaining("Expected null or empty details");
@@ -801,9 +801,9 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .isHealthy()
                                 .doesNotHaveDetailsContainingKey("someKey"))
                         .doesNotThrowAnyException();
@@ -811,9 +811,9 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                var healthCheck = newMockHealthCheckWithEmptyDetails();
+                var mockHealthCheck = newMockHealthCheckWithEmptyDetails();
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .isHealthy()
                                 .doesNotHaveDetailsContainingKey("someKey"))
                         .doesNotThrowAnyException();
@@ -844,9 +844,9 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreNull() {
-                var healthCheck = newHealthCheckWithNullDetails();
+                var theHealthCheck = newHealthCheckWithNullDetails();
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(theHealthCheck)
                                 .isHealthy()
                                 .doesNotHaveDetailsContainingKeys("someKey", "anotherKey", "yetAnotherKey"))
                         .doesNotThrowAnyException();
@@ -854,9 +854,9 @@ class HealthCheckResultAssertionsTest {
 
             @Test
             void shouldPass_WhenDetailsAreEmpty() {
-                var healthCheck = newMockHealthCheckWithEmptyDetails();
+                var mockHealthCheck = newMockHealthCheckWithEmptyDetails();
                 assertThatCode(() ->
-                        assertThat(healthCheck)
+                        assertThat(mockHealthCheck)
                                 .isHealthy()
                                 .doesNotHaveDetailsContainingKeys("someKey", "anotherKey", "yetAnotherKey"))
                         .doesNotThrowAnyException();

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.test.dropwizard.app;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 
@@ -206,7 +205,7 @@ class DropwizardAppTestsTest {
 
     @Test
     void shouldReturnStreamOfLifeCycleObjects() {
-        var lifeCycles = DropwizardAppTests.lifeCycleStreamOf(APP).collect(toList());
+        var lifeCycles = DropwizardAppTests.lifeCycleStreamOf(APP).toList();
         assertLifeCycleObjects(lifeCycles);
     }
 
@@ -219,7 +218,7 @@ class DropwizardAppTestsTest {
                 .filter(managed -> NoOpManaged.class.isAssignableFrom(managed.getClass()))
                 .map(NoOpManaged.class::cast)
                 .map(NoOpManaged::mischiefManaged)
-                .collect(toSet());
+                .collect(toUnmodifiableSet());
 
         assertThat(mischiefManaged).containsOnly(true);
     }
@@ -242,7 +241,7 @@ class DropwizardAppTestsTest {
         var classNames = listeners.stream()
                 .map(Object::getClass)
                 .map(Class::getName)
-                .collect(toList());
+                .toList();
 
         softly.assertThat(classNames).contains(DropwizardAppTests.DROPWIZARD_PRIVATE_SERVER_LISTENER_CLASS_NAME);
     }

--- a/src/test/java/org/kiwiproject/test/jaxrs/RequestResponseLoggerTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/RequestResponseLoggerTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.test.jaxrs;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
@@ -81,7 +80,7 @@ class RequestResponseLoggerTest {
         assertThat(records).hasSize(2);
         assertThat(records).extracting(LogRecord::getLoggerName).containsOnly("MyLogger");
 
-        var messages = records.stream().map(LogRecord::getMessage).collect(toList());
+        var messages = records.stream().map(LogRecord::getMessage).toList();
         assertThat(first(messages)).describedAs(CHECK_CLIENT_LOGGING_FILTER).contains(SENDING_CLIENT_REQUEST);
         assertThat(second(messages)).describedAs(CHECK_CLIENT_LOGGING_FILTER).contains(CLIENT_RESPONSE_RECEIVED);
 
@@ -91,7 +90,7 @@ class RequestResponseLoggerTest {
                 .hasSize(4);
         var latestMessages = records.stream()
                 .skip(2)
-                .map(LogRecord::getMessage).collect(toList());
+                .map(LogRecord::getMessage).toList();
         assertThat(first(latestMessages)).describedAs(CHECK_CLIENT_LOGGING_FILTER).contains(SENDING_CLIENT_REQUEST);
         assertThat(second(latestMessages)).describedAs(CHECK_CLIENT_LOGGING_FILTER).contains(CLIENT_RESPONSE_RECEIVED);
     }
@@ -109,8 +108,8 @@ class RequestResponseLoggerTest {
         }
 
         @Override
-        public void publish(final LogRecord record) {
-            records.add(record);
+        public void publish(final LogRecord logRecord) {
+            records.add(logRecord);
         }
 
         @Override

--- a/src/test/java/org/kiwiproject/test/junit/ParameterizedTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/ParameterizedTestHelperTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.test.junit;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -141,7 +140,7 @@ class ParameterizedTestHelperTest {
                 .map(message -> message.split(lineSeparator))
                 .map(lines -> lines[0])
                 .map(String::trim)
-                .collect(toList());
+                .toList();
     }
 
     private static class Request {

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionNeverCleanupTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionNeverCleanupTest.java
@@ -97,8 +97,8 @@ class MongoDbExtensionNeverCleanupTest {
     @Order(1)
     @Tag("firstTest")
     void shouldListCollections() {
-        var mongoDatabase = client.getDatabase(TEST_PROPERTIES.getDatabaseName());
-        assertThat(newArrayList(mongoDatabase.listCollectionNames().iterator())).isEmpty();
+        var theMongoDatabase = client.getDatabase(TEST_PROPERTIES.getDatabaseName());
+        assertThat(newArrayList(theMongoDatabase.listCollectionNames().iterator())).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -166,10 +166,7 @@ class MongoDbExtensionTest {
                 "yet-another-service_unit_test_localhost_1605410638221"
         })
         void shouldBeFalse_WhenDatabaseName_DoesNotContainTestDatabaseNameWithoutTimestamp(String databaseName) {
-            verifyTestPropertiesDatabaseName();
-
-            assertThat(MongoDbExtension.isUnitTestDatabaseForThisService(databaseName, testProperties))
-                    .isFalse();
+            assertNotUnitTestDatabaseForThisService(databaseName);
         }
 
         @ParameterizedTest
@@ -180,17 +177,17 @@ class MongoDbExtensionTest {
                 "customer_database"
         })
         void shouldBeFalse_WhenDatabaseName_IsNotInOurExpectedFormat(String databaseName) {
-            verifyTestPropertiesDatabaseName();
-
-            assertThat(MongoDbExtension.isUnitTestDatabaseForThisService(databaseName, testProperties))
-                    .isFalse();
+            assertNotUnitTestDatabaseForThisService(databaseName);
         }
 
-        private void verifyTestPropertiesDatabaseName() {
+        private void assertNotUnitTestDatabaseForThisService(String databaseName) {
             var testPropsDbName = testProperties.getDatabaseNameWithoutTimestamp();
             verify(testPropsDbName.equals("test-service_unit_test_localhost"),
                     "Expected testProperties database name (w/o timestamp) to be: test-service_unit_test_localhost but was: %s",
                     testPropsDbName);
+
+            assertThat(MongoDbExtension.isUnitTestDatabaseForThisService(databaseName, testProperties))
+                    .isFalse();
         }
     }
 

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProviderTest.java
@@ -13,16 +13,16 @@ class AsciiOnlyBlankStringArgumentsProviderTest {
     @ParameterizedTest
     @ArgumentsSource(AsciiOnlyBlankStringArgumentsProvider.class)
     void shouldProvideBlankArguments(String blankString) {
-        assertThat(blankString).isBlank();
-
-        if (nonNull(blankString)) {
-            assertOnlyAsciiCharactersIn(blankString);
-        }
+        assertProvidesBlankArguments(blankString);
     }
 
     @ParameterizedTest
     @AsciiOnlyBlankStringSource
     void shouldProvideBlankArgumentsUsingAnnotation(String blankString) {
+        assertProvidesBlankArguments(blankString);
+    }
+
+    private void assertProvidesBlankArguments(String blankString) {
         assertThat(blankString).isBlank();
 
         if (nonNull(blankString)) {

--- a/src/test/java/org/kiwiproject/test/util/FixturesTest.java
+++ b/src/test/java/org/kiwiproject/test/util/FixturesTest.java
@@ -127,7 +127,7 @@ class FixturesTest {
     class FixtureStripLeadingWhitespace {
 
         @Test
-        void shouldStripLeadingWhitespace() {
+        void shouldStripLeadingbutNotTrailingWhitespace() {
             var fixture = Fixtures.fixtureStripLeadingWhitespace(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE);
             var expected = Fixtures.fixture(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE).stripLeading();
             assertThat(fixture).isEqualTo(expected);
@@ -139,20 +139,13 @@ class FixturesTest {
             var expected = Fixtures.fixture(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE, StandardCharsets.UTF_8).stripLeading();
             assertThat(fixture).isEqualTo(expected);
         }
-
-        @Test
-        void shouldNotStripTrailingWhitespace() {
-            var fixture = Fixtures.fixtureStripLeadingWhitespace(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE);
-            var expected = Fixtures.fixture(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE).stripLeading();
-            assertThat(fixture).isEqualTo(expected);
-        }
     }
 
     @Nested
     class FixtureStripTrailingWhitespace {
 
         @Test
-        void shouldStripTrailingWhitespace() {
+        void shouldStripTrailingButNotLeadingWhitespace() {
             var fixture = Fixtures.fixtureStripTrailingWhitespace(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE);
             var expected = Fixtures.fixture(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE).stripTrailing();
             assertThat(fixture).isEqualTo(expected);
@@ -162,13 +155,6 @@ class FixturesTest {
         void shouldStripTrailingWhitespaceWithCharset() {
             var fixture = Fixtures.fixtureStripTrailingWhitespace(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE, StandardCharsets.UTF_8);
             var expected = Fixtures.fixture(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE, StandardCharsets.UTF_8).stripTrailing();
-            assertThat(fixture).isEqualTo(expected);
-        }
-
-        @Test
-        void shouldNotStripLeadingWhitespace() {
-            var fixture = Fixtures.fixtureStripTrailingWhitespace(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE);
-            var expected = Fixtures.fixture(PANGRAM_LEADING_TRAILING_WHITESPACE_FIXTURE).stripTrailing();
             assertThat(fixture).isEqualTo(expected);
         }
     }

--- a/src/test/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/validation/ParameterizedValidationTestHelperTest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.test.validation;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -295,7 +294,7 @@ class ParameterizedValidationTestHelperTest {
     private static List<String> extractErrorMessageFrom(Throwable thrown) {
         return ((AssertJMultipleFailuresError) thrown).getFailures().stream()
                 .map(Throwable::getMessage)
-                .collect(toList());
+                .toList();
     }
 
     @Data


### PR DESCRIPTION
* Local variables should not shadow class fields java:S1117
* Methods should not have identical implementations java:S4144
* "Stream.toList()" method should be used instead of "collectors" when unmodifiable list needed java:S6204
* Restricted Identifiers should not be used as Identifiers java:S6213