### PR TITLE
EXPERIMENTAL: Update to use alpha version of mockwebserver3-junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
         <!-- Versions for provided dependencies -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
 
-        <!-- This version must match the okhttp version in kiwi-bom. TODO: Consider adding this to kiwi-bom. -->
-        <ohttp3.mockwebserver.version>4.12.0</ohttp3.mockwebserver.version>
+        <!-- TODO: This is an ALPHA version!!! This is an EXPERIMENTAL branch only!!! Consider adding this to kiwi-bom. -->
+        <okhttp3.mockwebserver3.version>5.0.0-alpha.14</okhttp3.mockwebserver3.version>
 
         <xmlunit.version>2.10.0</xmlunit.version>
 
@@ -53,6 +53,14 @@
                 <version>${kiwi-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Override version in kiwi-bom to ensure okhttp artifacts have same version
+                 TODO: Remove once okhttp and mockwebserver3 versions are in sync -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp3.mockwebserver3.version}</version>
             </dependency>
 
             <dependency>
@@ -195,8 +203,8 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>${ohttp3.mockwebserver.version}</version>
+            <artifactId>mockwebserver3-junit5</artifactId>
+            <version>${okhttp3.mockwebserver3.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequests.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequests.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import org.kiwiproject.base.UncheckedInterruptedException;
 
 import java.util.Optional;

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestsTest.java
@@ -14,18 +14,18 @@ import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
+import mockwebserver3.junit5.internal.MockWebServerExtension;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Durations;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.base.UncheckedInterruptedException;
-import org.kiwiproject.io.KiwiIO;
 
 import java.io.IOException;
 import java.net.URI;
@@ -40,17 +40,14 @@ import java.util.concurrent.TimeUnit;
 @DisplayName("RecordedRequests")
 class RecordedRequestsTest {
 
+    @RegisterExtension
+    static final MockWebServerExtension MOCK_WEB_SERVER_EXTENSION = new MockWebServerExtension();
+
     private MockWebServer server;
 
     @BeforeEach
-    void setUp() throws IOException {
-        server = new MockWebServer();
-        server.start();
-    }
-
-    @AfterEach
-    void tearDown() {
-        KiwiIO.closeQuietly(server);
+    void setUp(MockWebServer server) {
+        this.server = server;
     }
 
     @Nested
@@ -58,7 +55,7 @@ class RecordedRequestsTest {
 
         @Test
         void shouldReturnTheAvailableRequest() {
-            server.enqueue(new MockResponse().setResponseCode(200));
+            server.enqueue(new MockResponse(200));
 
             var path = randomPath();
             makeRequest(path);
@@ -81,7 +78,7 @@ class RecordedRequestsTest {
 
         @Test
         void shouldReturnTheAvailableRequest() {
-            server.enqueue(new MockResponse().setResponseCode(202));
+            server.enqueue(new MockResponse(202));
 
             var path = randomPath();
             makeRequest(path);
@@ -109,7 +106,7 @@ class RecordedRequestsTest {
 
         @Test
         void shouldFail_WhenAnyRequestIsAvailable() {
-            server.enqueue(new MockResponse().setResponseCode(202));
+            server.enqueue(new MockResponse(202));
 
             var path = randomPath();
             makeRequest(path);
@@ -126,7 +123,7 @@ class RecordedRequestsTest {
 
         @Test
         void shouldReturnTheAvailableRequest() {
-            server.enqueue(new MockResponse().setResponseCode(204));
+            server.enqueue(new MockResponse(204));
 
             var path = randomPath();
             makeRequest(path);

--- a/src/test/java/org/kiwiproject/test/xmlunit/KiwiXmlAssertTest.java
+++ b/src/test/java/org/kiwiproject/test/xmlunit/KiwiXmlAssertTest.java
@@ -45,12 +45,16 @@ class KiwiXmlAssertTest {
             var xml = fixture("KiwiXmlAssertTest/alice-smith.xml");
             var otherXml = fixture("KiwiXmlAssertTest/alice-jones.xml");
 
+            // TODO: Should we revert this to use 'isExactlyInstanceOf' now that JUnit 4
+            //  is no longer present. See the "Gory Details" in the following PR for why
+            //  that matters: https://github.com/kiwiproject/kiwi-test/pull/499
+            //  For now, they have been changed to verify the tests pass.
             assertThatThrownBy(() ->
                     KiwiXmlAssert.assertThat(xml)
                             .withTestName("custom-test-name")
                             .and(otherXml)
                             .areIdentical())
-                    .isInstanceOf(AssertionError.class);
+                    .isExactlyInstanceOf(AssertionError.class);
         }
 
         @Test
@@ -63,7 +67,7 @@ class KiwiXmlAssertTest {
                             .withTestNameFrom(testInfo)
                             .and(otherXml)
                             .areIdentical())
-                    .isInstanceOf(AssertionError.class);
+                    .isExactlyInstanceOf(AssertionError.class);
         }
     }
 
@@ -108,7 +112,7 @@ class KiwiXmlAssertTest {
 
                 assertThatThrownBy(() ->
                         KiwiXmlAssert.assertThat(xml).isIdenticalTo(otherXml))
-                        .isInstanceOf(AssertionError.class);
+                        .isExactlyInstanceOf(AssertionError.class);
             }
         }
 
@@ -136,7 +140,7 @@ class KiwiXmlAssertTest {
 
                 assertThatThrownBy(() ->
                         KiwiXmlAssert.assertThat(xml).isIdenticalToIgnoringWhitespace(otherXml))
-                        .isInstanceOf(AssertionError.class);
+                        .isExactlyInstanceOf(AssertionError.class);
             }
         }
 
@@ -165,7 +169,7 @@ class KiwiXmlAssertTest {
 
                 assertThatThrownBy(() ->
                         KiwiXmlAssert.assertThat(xml).isIdenticalToIgnoringComments(otherXml))
-                        .isInstanceOf(AssertionError.class);
+                        .isExactlyInstanceOf(AssertionError.class);
             }
         }
 
@@ -189,7 +193,7 @@ class KiwiXmlAssertTest {
 
                 assertThatThrownBy(() ->
                         KiwiXmlAssert.assertThat(xml).isIdenticalToIgnoringWhitespaceAndComments(otherXml))
-                        .isInstanceOf(AssertionError.class);
+                        .isExactlyInstanceOf(AssertionError.class);
             }
         }
     }


### PR DESCRIPTION
This is an experimental branch, not intended to commit to main since it is using an alpha version of OkHttp's MockWebServer which is using experimental APIs, subject to change. This is mainly to show how we can change when OkHttp 5.0.0 is released. It is also to ensure we keep up with changes to the alpha APIs.

Details:

* Change POM to use mockwebserver3-junit5 5.0.0-alpha.14 instead of mockwebserver 4.12.0
* Fix imports in RecordedRequests/Test (they're now just "import mockwebserver3.*"
* Update RecordedRequestsTest to use MockWebServerExtension and inject it into the setup method. No longer need to explicitly close it, since the extension handles that. Change instantiations of MockResponse since they've changed them such that the Kotlin code uses JvmOverloads to generate a bunch of constructors for use by Java code.
* Revert KiwiXmlAssertTest to use isExactlyInstanceOf instead of isInstanceOf and add a TODO whether we should actually do that or leave as isInstanceOf.