### PR TITLE
Add fluent assertions for MockWebServer and RecordedRequest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,15 +256,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- test dependencies -->
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp-tls</artifactId>
-            <version>${ohttp3.mockwebserver.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,15 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-tls</artifactId>
+            <version>${ohttp3.mockwebserver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertions.java
@@ -26,14 +26,36 @@ public class MockWebServerAssertions {
         this.mockWebServer = requireNotNull(mockWebServer);
     }
 
+    /**
+     * Starting point for fluent assertions on {@link MockWebServer}.
+     *
+     * @param mockWebServer the {@link MockWebServer} to assert upon
+     * @return this instance
+     */
     public static MockWebServerAssertions assertThat(MockWebServer mockWebServer) {
         return assertThatMockWebServer(mockWebServer);
     }
 
+    /**
+     * Starting point for fluent assertions on {@link MockWebServer}.
+     * <p>
+     * This method is provided as an alias of {@link #assertThat(MockWebServer)} to avoid conflicts
+     * when statically importing AssertJ's {@code Assertions#assertThat}, and therefore allow both
+     * to be statically imported.
+     *
+     * @param mockWebServer the {@link MockWebServer} to assert upon
+     * @return this instance
+     */
     public static MockWebServerAssertions assertThatMockWebServer(MockWebServer mockWebServer) {
         return new MockWebServerAssertions(mockWebServer);
     }
 
+    /**
+     * Asserts the {@link MockWebServer} has the expected request count.
+     *
+     * @param requestCount the expected request count
+     * @return this instance
+     */
     public MockWebServerAssertions hasRequestCount(int requestCount) {
         Assertions.assertThat(mockWebServer.getRequestCount())
                 .describedAs("Expected request count to be: %d", requestCount)
@@ -42,6 +64,13 @@ public class MockWebServerAssertions {
         return this;
     }
 
+    /**
+     * Asserts the {@link MockWebServer} has the next {@link RecordedRequest} that satisfies
+     * assertions provided by the {@code recordedRequestConsumer}.
+     *
+     * @param recordedRequestConsumer the {@link Consumer} containing the assertions on the {@link RecordedRequest}
+     * @return this instance
+     */
     public MockWebServerAssertions hasRecordedRequest(Consumer<RecordedRequest> recordedRequestConsumer) {
         var requestOrNull = RecordedRequests.takeRequestOrNull(mockWebServer);
         recordedRequestConsumer.accept(requestOrNull);
@@ -49,6 +78,13 @@ public class MockWebServerAssertions {
         return this;
     }
 
+    /**
+     * This is a terminal method that gets the next {@link RecordedRequest} (or {@code null})
+     * and makes it available as a {@link RecordedRequestAssertions} instance for further
+     * assertion chaining.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions recordedRequest() {
         var requestOrNull = RecordedRequests.takeRequestOrNull(mockWebServer);
         return RecordedRequestAssertions.assertThatRecordedRequest(requestOrNull);

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertions.java
@@ -1,0 +1,46 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.assertj.core.api.Assertions;
+
+import java.util.function.Consumer;
+
+public class MockWebServerAssertions {
+
+    private final MockWebServer mockWebServer;
+
+    private MockWebServerAssertions(MockWebServer mockWebServer) {
+        this.mockWebServer = requireNotNull(mockWebServer);
+    }
+
+    public static MockWebServerAssertions assertThat(MockWebServer mockWebServer) {
+        return assertThatMockWebServer(mockWebServer);
+    }
+
+    public static MockWebServerAssertions assertThatMockWebServer(MockWebServer mockWebServer) {
+        return new MockWebServerAssertions(mockWebServer);
+    }
+
+    public MockWebServerAssertions hasRequestCount(int requestCount) {
+        Assertions.assertThat(mockWebServer.getRequestCount())
+                .describedAs("Expected request count to be: %d", requestCount)
+                .isEqualTo(requestCount);
+
+        return this;
+    }
+
+    public MockWebServerAssertions hasRecordedRequest(Consumer<RecordedRequest> recordedRequestConsumer) {
+        var requestOrNull = RecordedRequests.takeRequestOrNull(mockWebServer);
+        recordedRequestConsumer.accept(requestOrNull);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions recordedRequest() {
+        var requestOrNull = RecordedRequests.takeRequestOrNull(mockWebServer);
+        return RecordedRequestAssertions.assertThatRecordedRequest(requestOrNull);
+    }
+}

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertions.java
@@ -8,6 +8,16 @@ import org.assertj.core.api.Assertions;
 
 import java.util.function.Consumer;
 
+/**
+ * Provides for fluent {@link MockWebServer} and {@link RecordedRequest} tests
+ * using AssertJ assertions.
+ * <p>
+ * All methods return 'this' to facilitate a fluent API via method chaining.
+ * <p>
+ * Note that MockWebServer (com.squareup.okhttp3:mockwebserver) and OkHttp
+ * dependencies must be available at runtime. OkHttp is a transitive dependency
+ * of mockwebserver, so you should only need to add mockwebserver.
+ */
 public class MockWebServerAssertions {
 
     private final MockWebServer mockWebServer;

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
@@ -5,6 +5,13 @@ import okhttp3.mockwebserver.MockWebServer;
 
 import java.net.URI;
 
+/**
+ * Static test utilities related to {@link MockWebServer}.
+ * <p>
+ * Note that MockWebServer (com.squareup.okhttp3:mockwebserver) and OkHttp
+ * dependencies must be available at runtime. OkHttp is a transitive dependency
+ * of mockwebserver, so you should only need to add mockwebserver.
+ */
 @UtilityClass
 public class MockWebServers {
 

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
@@ -1,0 +1,15 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import lombok.experimental.UtilityClass;
+
+import java.net.URI;
+
+import okhttp3.mockwebserver.MockWebServer;
+
+@UtilityClass
+public class MockWebServers {
+
+    public static URI uri(MockWebServer server, String path) {
+        return URI.create(server.url(path).toString());
+    }
+}

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
@@ -1,10 +1,9 @@
 package org.kiwiproject.test.okhttp3.mockwebserver;
 
 import lombok.experimental.UtilityClass;
+import okhttp3.mockwebserver.MockWebServer;
 
 import java.net.URI;
-
-import okhttp3.mockwebserver.MockWebServer;
 
 @UtilityClass
 public class MockWebServers {

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServers.java
@@ -15,6 +15,16 @@ import java.net.URI;
 @UtilityClass
 public class MockWebServers {
 
+    /**
+     * Create a {@link URI} which can be used to make HTTP (or HTTPS) requests
+     * to the given {@link MockWebServer}.
+     * <p>
+     * Appends the given path to the server base URL.
+     *
+     * @param server the {@link MockWebServer}
+     * @param path   the path relative to the server's base URI
+     * @return a {@link URI} to connect to the server, with the given path
+     */
     public static URI uri(MockWebServer server, String path) {
         return URI.create(server.url(path).toString());
     }

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -1,0 +1,214 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import okhttp3.TlsVersion;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.assertj.core.api.Assertions;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.function.Consumer;
+
+public class RecordedRequestAssertions {
+
+    private final RecordedRequest recordedRequest;
+
+    private RecordedRequestAssertions(RecordedRequest recordedRequest) {
+        this.recordedRequest = requireNotNull(recordedRequest);
+    }
+
+    public static RecordedRequestAssertions assertThat(RecordedRequest recordedRequest) {
+        return assertThatRecordedRequest(recordedRequest);
+    }
+
+    public static RecordedRequestAssertions assertThatRecordedRequest(RecordedRequest recordedRequest) {
+        return new RecordedRequestAssertions(recordedRequest);
+    }
+
+    // References on HTTP methods:
+    //  - Request Line:    https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1
+    //  - Request Methods: https://datatracker.ietf.org/doc/html/rfc7231#section-4
+    //  - PATCH method:    https://datatracker.ietf.org/doc/html/rfc5789
+
+    public RecordedRequestAssertions isGET() {
+        return hasMethod("GET");
+    }
+
+    public RecordedRequestAssertions isPOST() {
+        return hasMethod("POST");
+    }
+
+    public RecordedRequestAssertions isPUT() {
+        return hasMethod("PUT");
+    }
+
+    public RecordedRequestAssertions isDELETE() {
+        return hasMethod("DELETE");
+    }
+
+    public RecordedRequestAssertions isHEAD() {
+        return hasMethod("HEAD");
+    }
+
+    public RecordedRequestAssertions isCONNECT() {
+        return hasMethod("CONNECT");
+    }
+
+    public RecordedRequestAssertions isOPTIONS() {
+        return hasMethod("OPTIONS");
+    }
+
+    public RecordedRequestAssertions isTRACE() {
+        return hasMethod("TRACE");
+    }
+
+    public RecordedRequestAssertions isPATCH() {
+        return hasMethod("PATCH");
+    }
+
+    public RecordedRequestAssertions hasMethod(String method) {
+        Assertions.assertThat(recordedRequest.getMethod())
+                .describedAs("Expected method to be %s", method)
+                .isEqualTo(method);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasRequestLine(String requestLine) {
+        Assertions.assertThat(recordedRequest.getRequestLine())
+                .describedAs("Expected request line to be: %s", requestLine)
+                .isEqualTo(requestLine);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasRequestUrl(URI requestUrl) {
+        return hasRequestUrl(requestUrl.toString());
+    }
+
+    public RecordedRequestAssertions hasRequestUrl(String requestUrl) {
+        Assertions.assertThat(recordedRequest.getRequestUrl().toString())
+                .describedAs("Expected request URL to be: %s", requestUrl)
+                .isEqualTo(requestUrl);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasPath(String path) {
+        Assertions.assertThat(recordedRequest.getPath())
+                .describedAs("Expected path to be: %s", path)
+                .isEqualTo(path);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasHeader(String name, Object value) {
+        Assertions.assertThat(recordedRequest.getHeader(name))
+                .describedAs("Expected %s header to have value: %s", name, value)
+                .isEqualTo(value);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasNoBody() {
+        var bodyBuffer = recordedRequest.getBody();
+        Assertions.assertThat(bodyBuffer.size())
+                .describedAs("Expected there not to be a request body but found: %s",
+                        bodyBuffer.readUtf8())
+                .isZero();
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasBody(String body) {
+        var bodyBuffer = recordedRequest.getBody();
+        var actualBodyUtf8 = bodyBuffer.readUtf8();
+        Assertions.assertThat(actualBodyUtf8)
+                .describedAs("Expected body as UTF-8 to be: %s", body)
+                .isEqualTo(body);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasBodySize(long size) {
+        // TODO - this only applies to POST/PUT/PATCH requests!!! put in javadoc
+        //  should we throw if the method is not one of the expected ones???
+
+        Assertions.assertThat(recordedRequest.getBodySize())
+                .describedAs("Expected body size: %d bytes", size)
+                .isEqualTo(size);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions isNotTls() {
+        Assertions.assertThat(recordedRequest.getTlsVersion())
+                .describedAs("Expected request not to use TLS")
+                .isNull();
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasTlsVersion(TlsVersion tlsVersion) {
+        Assertions.assertThat(recordedRequest.getTlsVersion())
+                .describedAs("Expected TLS version to be %s", tlsVersion)
+                .isEqualTo(tlsVersion);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasNoFailure() {
+        Assertions.assertThat(recordedRequest.getFailure())
+                .describedAs("Expected request not to have failure")
+                .isNull();
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasFailureMessage(String failureMessage) {
+        Assertions.assertThat(recordedRequest.getFailure())
+                .describedAs("Expected a failure with message: %s", failureMessage)
+                .hasMessage(failureMessage);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasFailureMessageContaining(String failureMessage) {
+        Assertions.assertThat(recordedRequest.getFailure())
+                .describedAs("Expected a failure with message that contains: %s", failureMessage)
+                .hasMessageContaining(failureMessage);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasFailureMessageStartingWith(String failureMessage) {
+        Assertions.assertThat(recordedRequest.getFailure())
+                .describedAs("Expected a failure with message that starts with: %s", failureMessage)
+                .hasMessageStartingWith(failureMessage);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasFailureMessageEndingWith(String failureMessage) {
+        Assertions.assertThat(recordedRequest.getFailure())
+                .describedAs("Expected a failure with message that ends with: %s", failureMessage)
+                .hasMessageEndingWith(failureMessage);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasFailureCauseInstanceOf(Class<?> causeType) {
+        Assertions.assertThat(recordedRequest.getFailure())
+                .describedAs("Expected request to have failure of type: %s", causeType.getName())
+                .isInstanceOf(causeType);
+
+        return this;
+    }
+
+    public RecordedRequestAssertions hasFailure(Consumer<IOException> failureConsumer) {
+        failureConsumer.accept(recordedRequest.getFailure());
+
+        return this;
+    }
+}

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -12,6 +12,15 @@ import java.net.URI;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * Provides for fluent {@link RecordedRequest} tests using AssertJ assertions.
+ * <p>
+ * All methods return 'this' to facilitate a fluent API via method chaining.
+ * <p>
+ * Note that MockWebServer (com.squareup.okhttp3:mockwebserver) and OkHttp
+ * dependencies must be available at runtime. OkHttp is a transitive dependency
+ * of mockwebserver, so you should only need to add mockwebserver.
+ */
 @CanIgnoreReturnValue
 public class RecordedRequestAssertions {
 

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.okhttp3.mockwebserver;
 
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import okhttp3.TlsVersion;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.Assertions;
@@ -10,6 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.function.Consumer;
 
+@CanIgnoreReturnValue
 public class RecordedRequestAssertions {
 
     private final RecordedRequest recordedRequest;
@@ -88,9 +90,10 @@ public class RecordedRequestAssertions {
     }
 
     public RecordedRequestAssertions hasRequestUrl(String requestUrl) {
-        Assertions.assertThat(recordedRequest.getRequestUrl().toString())
+        Assertions.assertThat(recordedRequest.getRequestUrl())
                 .describedAs("Expected request URL to be: %s", requestUrl)
-                .isEqualTo(requestUrl);
+                .isNotNull()
+                .hasToString(requestUrl);
 
         return this;
     }

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -33,10 +33,26 @@ public class RecordedRequestAssertions {
         this.recordedRequest = requireNotNull(recordedRequest);
     }
 
+    /**
+     * Starting point for fluent assertions on {@link RecordedRequest}.
+     *
+     * @param recordedRequest the {@link RecordedRequest} to assert upon
+     * @return this instance
+     */
     public static RecordedRequestAssertions assertThat(RecordedRequest recordedRequest) {
         return assertThatRecordedRequest(recordedRequest);
     }
 
+    /**
+     * Starting point for fluent assertions on {@link RecordedRequest}.
+     * <p>
+     * This method is provided as an alias of {@link #assertThat(RecordedRequest)} to avoid conflicts
+     * when statically importing AssertJ's {@code Assertions#assertThat}, and therefore allow both
+     * to be statically imported.
+     *
+     * @param recordedRequest the {@link RecordedRequest} to assert upon
+     * @return this instance
+     */
     public static RecordedRequestAssertions assertThatRecordedRequest(RecordedRequest recordedRequest) {
         return new RecordedRequestAssertions(recordedRequest);
     }

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -63,42 +63,93 @@ public class RecordedRequestAssertions {
     //  - PATCH method:    https://datatracker.ietf.org/doc/html/rfc5789
     //  - Mozilla - HTTP request methods - https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
 
+    /**
+     * Asserts the recorded request is a GET request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isGET() {
         return hasMethod("GET");
     }
 
+    /**
+     * Asserts the recorded request is a POST request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isPOST() {
         return hasMethod("POST");
     }
 
+    /**
+     * Asserts the recorded request is a PUT request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isPUT() {
         return hasMethod("PUT");
     }
 
+    /**
+     * Asserts the recorded request is a DELETE request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isDELETE() {
         return hasMethod("DELETE");
     }
 
+    /**
+     * Asserts the recorded request is a HEAD request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isHEAD() {
         return hasMethod("HEAD");
     }
 
+    /**
+     * Asserts the recorded request is a CONNECT request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isCONNECT() {
         return hasMethod("CONNECT");
     }
 
+    /**
+     * Asserts the recorded request is an OPTIONS request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isOPTIONS() {
         return hasMethod("OPTIONS");
     }
 
+    /**
+     * Asserts the recorded request is a TRACE request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isTRACE() {
         return hasMethod("TRACE");
     }
 
+    /**
+     * Asserts the recorded request is a PATCH request.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isPATCH() {
         return hasMethod("PATCH");
     }
 
+    /**
+     * Asserts the recorded request has the expected HTTP method.
+     *
+     * @param method the expected request method
+     * @return this instance
+     */
     public RecordedRequestAssertions hasMethod(String method) {
         Assertions.assertThat(recordedRequest.getMethod())
                 .describedAs("Expected method to be %s", method)
@@ -107,6 +158,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has the expected HTTP request line.
+     *
+     * @param requestLine the expected request line
+     * @return this instance
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages">HTTP Messages</a>
+     */
     public RecordedRequestAssertions hasRequestLine(String requestLine) {
         Assertions.assertThat(recordedRequest.getRequestLine())
                 .describedAs("Expected request line to be: %s", requestLine)
@@ -115,10 +173,22 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has the expected request URL.
+     *
+     * @param requestUrl the expected request URL (as a {@link URI})
+     * @return this instance
+     */
     public RecordedRequestAssertions hasRequestUrl(URI requestUrl) {
         return hasRequestUrl(requestUrl.toString());
     }
 
+    /**
+     * Asserts the recorded request has the expected request URL.
+     *
+     * @param requestUrl the expected request URL
+     * @return this instance
+     */
     public RecordedRequestAssertions hasRequestUrl(String requestUrl) {
         Assertions.assertThat(recordedRequest.getRequestUrl())
                 .describedAs("Expected request URL to be: %s", requestUrl)
@@ -128,6 +198,12 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has the expected path.
+     *
+     * @param path the expected path
+     * @return this instance
+     */
     public RecordedRequestAssertions hasPath(String path) {
         Assertions.assertThat(recordedRequest.getPath())
                 .describedAs("Expected path to be: %s", path)
@@ -136,6 +212,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has the expected header name and value.
+     *
+     * @param name  the expected HTTP header name
+     * @param value the expected HTTP header value
+     * @return this instance
+     */
     public RecordedRequestAssertions hasHeader(String name, Object value) {
         Assertions.assertThat(recordedRequest.getHeader(name))
                 .describedAs("Expected %s header to have value: %s", name, value)
@@ -144,6 +227,14 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request does not have a request body.
+     * <p>
+     * Only DELETE, PATCH, POST, and PUT may have a body.
+     *
+     * @return this instance
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods">HTTP request methods</a>
+     */
     public RecordedRequestAssertions hasNoBody() {
         var bodyBuffer = recordedRequest.getBody();
         Assertions.assertThat(bodyBuffer.size())
@@ -154,6 +245,15 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has the expected body.
+     * <p>
+     * Only DELETE, PATCH, POST, and PUT may have a body.
+     *
+     * @param body the expected request body (assumes UTF-8 character encoding)
+     * @return this instance
+     * @see okio.Buffer#readUtf8()
+     */
     public RecordedRequestAssertions hasBody(String body) {
         checkMethodAllowsBody();
 
@@ -166,6 +266,12 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a body of the given size.
+     *
+     * @param size the expected body size
+     * @return this instance
+     */
     public RecordedRequestAssertions hasBodySize(long size) {
         checkMethodAllowsBody();
 
@@ -185,6 +291,11 @@ public class RecordedRequestAssertions {
                 .isIn(METHODS_ALLOWING_BODY);
     }
 
+    /**
+     * Asserts the recorded request is not TLS, i.e., is an HTTP request not HTTPS.
+     *
+     * @return this instance
+     */
     public RecordedRequestAssertions isNotTls() {
         Assertions.assertThat(recordedRequest.getTlsVersion())
                 .describedAs("Expected request not to use TLS")
@@ -193,6 +304,12 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request is TLS with the expected version.
+     *
+     * @param tlsVersion the expected TLS version
+     * @return this instance
+     */
     public RecordedRequestAssertions hasTlsVersion(TlsVersion tlsVersion) {
         Assertions.assertThat(recordedRequest.getTlsVersion())
                 .describedAs("Expected TLS version to be %s", tlsVersion)
@@ -201,6 +318,19 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request does not have a failure, which is an {@link IOException}.
+     * <p>
+     * Note that usually an {@link IOException} is thrown by the code making the HTTP request.
+     * For example, if you set the {@link okhttp3.mockwebserver.SocketPolicy SocketPolicy} to
+     * {@link okhttp3.mockwebserver.SocketPolicy#DISCONNECT_AT_START DISCONNECT_AT_START} or
+     * {@link okhttp3.mockwebserver.SocketPolicy#DISCONNECT_DURING_REQUEST_BODY DISCONNECT_DURING_REQUEST_BODY},
+     * then the HTTP client code throws {@link IOException} but the {@link RecordedRequest}
+     * <em>usually</em> does not contain that failure.
+     *
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasNoFailure() {
         Assertions.assertThat(recordedRequest.getFailure())
                 .describedAs("Expected request not to have failure")
@@ -209,6 +339,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a failure with the given message.
+     *
+     * @param failureMessage the expected message from the {@link IOException}
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasFailureMessage(String failureMessage) {
         Assertions.assertThat(recordedRequest.getFailure())
                 .describedAs("Expected a failure with message: %s", failureMessage)
@@ -217,6 +354,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a failure whose message contains the given value.
+     *
+     * @param failureMessage the expected partial message from the {@link IOException}
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasFailureMessageContaining(String failureMessage) {
         Assertions.assertThat(recordedRequest.getFailure())
                 .describedAs("Expected a failure with message that contains: %s", failureMessage)
@@ -225,6 +369,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a failure whose message starts with the given value.
+     *
+     * @param failureMessage the expected partial message from the {@link IOException}
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasFailureMessageStartingWith(String failureMessage) {
         Assertions.assertThat(recordedRequest.getFailure())
                 .describedAs("Expected a failure with message that starts with: %s", failureMessage)
@@ -233,6 +384,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a failure whose message ends with the given value.
+     *
+     * @param failureMessage the expected partial message from the {@link IOException}
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasFailureMessageEndingWith(String failureMessage) {
         Assertions.assertThat(recordedRequest.getFailure())
                 .describedAs("Expected a failure with message that ends with: %s", failureMessage)
@@ -241,6 +399,13 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a failure ({@link IOException}) with the given cause.
+     *
+     * @param causeType the cause, obtained via {@link IOException#getCause()}
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasFailureCauseInstanceOf(Class<?> causeType) {
         Assertions.assertThat(recordedRequest.getFailure())
                 .describedAs("Expected request to have failure of type: %s", causeType.getName())
@@ -249,6 +414,14 @@ public class RecordedRequestAssertions {
         return this;
     }
 
+    /**
+     * Asserts the recorded request has a failure that satisfies assertions
+     * provided by the {@code failureConsumer}.
+     *
+     * @param failureConsumer the {@link Consumer} containing the assertions on the recorded request failure.
+     * @return this instance
+     * @see RecordedRequest#getFailure()
+     */
     public RecordedRequestAssertions hasFailure(Consumer<IOException> failureConsumer) {
         failureConsumer.accept(recordedRequest.getFailure());
 

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/JdkHttpClients.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/JdkHttpClients.java
@@ -1,0 +1,55 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import lombok.experimental.UtilityClass;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+
+@UtilityClass
+class JdkHttpClients {
+
+    static HttpResponse<String> get(HttpClient client, String uri) {
+        return get(client, URI.create(uri));
+    }
+
+    static HttpResponse<String> get(HttpClient client, URI uri) {
+        return send(client, HttpRequest.newBuilder()
+                .GET()
+                .uri(uri)
+                .build());
+    }
+
+    static HttpResponse<String> post(HttpClient client, URI uri, String body) {
+        return send(client, HttpRequest.newBuilder()
+                .POST(BodyPublishers.ofString(body))
+                .uri(uri)
+                .build());
+    }
+
+    static HttpResponse<String> put(HttpClient client, URI uri, String body) {
+        return send(client, HttpRequest.newBuilder()
+                .PUT(BodyPublishers.ofString(body))
+                .uri(uri)
+                .build());
+    }
+
+    static HttpResponse<String> delete(HttpClient client, URI uri) {
+        return send(client, HttpRequest.newBuilder()
+                .DELETE()
+                .uri(uri)
+                .build());
+    }
+
+    static HttpResponse<String> send(HttpClient client, HttpRequest request) {
+        try {
+            return client.send(request, BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/JdkHttpClients.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/JdkHttpClients.java
@@ -11,6 +11,9 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 
+/**
+ * Testing utilities for making requests using the JDK's {@link HttpClient}.
+ */
 @UtilityClass
 class JdkHttpClients {
 

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/JdkHttpClients.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/JdkHttpClients.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.test.okhttp3.mockwebserver;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import lombok.experimental.UtilityClass;
 
 import java.io.IOException;
@@ -13,10 +14,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 @UtilityClass
 class JdkHttpClients {
 
-    static HttpResponse<String> get(HttpClient client, String uri) {
-        return get(client, URI.create(uri));
-    }
-
+    @CanIgnoreReturnValue
     static HttpResponse<String> get(HttpClient client, URI uri) {
         return send(client, HttpRequest.newBuilder()
                 .GET()
@@ -24,6 +22,7 @@ class JdkHttpClients {
                 .build());
     }
 
+    @CanIgnoreReturnValue
     static HttpResponse<String> post(HttpClient client, URI uri, String body) {
         return send(client, HttpRequest.newBuilder()
                 .POST(BodyPublishers.ofString(body))
@@ -31,6 +30,7 @@ class JdkHttpClients {
                 .build());
     }
 
+    @CanIgnoreReturnValue
     static HttpResponse<String> put(HttpClient client, URI uri, String body) {
         return send(client, HttpRequest.newBuilder()
                 .PUT(BodyPublishers.ofString(body))
@@ -38,6 +38,7 @@ class JdkHttpClients {
                 .build());
     }
 
+    @CanIgnoreReturnValue
     static HttpResponse<String> delete(HttpClient client, URI uri) {
         return send(client, HttpRequest.newBuilder()
                 .DELETE()
@@ -45,6 +46,7 @@ class JdkHttpClients {
                 .build());
     }
 
+    @CanIgnoreReturnValue
     static HttpResponse<String> send(HttpClient client, HttpRequest request) {
         try {
             return client.send(request, BodyHandlers.ofString());

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
@@ -5,13 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.kiwiproject.io.KiwiIO;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
@@ -19,22 +17,19 @@ import java.time.Duration;
 @DisplayName("MockWebServerAssertions")
 class MockWebServerAssertionsTest {
 
+    @RegisterExtension
+    private final MockWebServerExtension mockWebServerExtension = new MockWebServerExtension();
+
     private MockWebServer server;
     private HttpClient httpClient;
 
     @BeforeEach
-    void setUp() throws IOException {
-        server = new MockWebServer();
-        server.start();
+    void setUp() {
+        server = mockWebServerExtension.server();
 
         httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofMillis(100))
                 .build();
-    }
-
-    @AfterEach
-    void tearDown() {
-        KiwiIO.closeQuietly(server);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
@@ -3,6 +3,8 @@ package org.kiwiproject.test.okhttp3.mockwebserver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,9 +15,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 
 @DisplayName("MockWebServerAssertions")
 class MockWebServerAssertionsTest {

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
@@ -43,7 +43,7 @@ class MockWebServerAssertionsTest {
     }
 
     @Test
-    void shouldPassSuccessfulGETRequests() throws InterruptedException {
+    void shouldPassSuccessfulGETRequests() {
         server.enqueue(new MockResponse());
 
         var path = "/status";

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
@@ -1,0 +1,96 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.io.KiwiIO;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+@DisplayName("MockWebServerAssertions")
+class MockWebServerAssertionsTest {
+
+    private MockWebServer server;
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(100))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        KiwiIO.closeQuietly(server);
+    }
+
+    @Test
+    void shouldCreateUsingAssertThat() {
+        MockWebServerAssertions.assertThat(server).hasRequestCount(0);
+    }
+
+    @Test
+    void shouldPassSuccessfulGETRequests() throws InterruptedException {
+        server.enqueue(new MockResponse());
+
+        var path = "/status";
+        var url = server.url(path).toString();
+        var uri = URI.create(url);
+        JdkHttpClients.get(httpClient, uri);
+
+        assertThatCode(() ->
+                    MockWebServerAssertions.assertThatMockWebServer(server)
+                        .hasRequestCount(1)
+                        .recordedRequest()
+                            .isGET()
+                            .hasPath(path))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAllowCheckingMultipeRecordedRequests() {
+        server.enqueue(new MockResponse());
+        server.enqueue(new MockResponse().setResponseCode(201));
+
+        var path1 = "/status";
+        var url1 = server.url(path1).toString();
+        var uri1 = URI.create(url1);
+        JdkHttpClients.get(httpClient, uri1);
+
+        var path2 = "/create";
+        var url2 = server.url(path2).toString();
+        var uri2 = URI.create(url2);
+        var body = """
+                    { "name": "Bob" }
+                    """;
+        JdkHttpClients.post(httpClient, uri2, body);
+
+        assertThatCode(() ->
+                    MockWebServerAssertions.assertThatMockWebServer(server)
+                        .hasRequestCount(2)
+                        .hasRecordedRequest(recordedRequest -> {
+                            assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+                            assertThat(recordedRequest.getPath()).isEqualTo(path1);
+                        })
+                        .hasRecordedRequest(recordedRequest -> {
+                            assertThat(recordedRequest.getMethod()).isEqualTo("POST");
+                            assertThat(recordedRequest.getPath()).isEqualTo(path2);
+                            assertThat(recordedRequest.getBody().readUtf8()).isEqualTo(body);
+                        }))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -1,0 +1,29 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.io.KiwiIO;
+
+import java.io.IOException;
+
+public class MockWebServerExtension implements BeforeEachCallback, AfterEachCallback {
+
+    @Getter
+    @Accessors(fluent = true)
+    private MockWebServer server;
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        KiwiIO.closeQuietly(server);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -10,6 +10,10 @@ import org.kiwiproject.io.KiwiIO;
 
 import java.io.IOException;
 
+/**
+ * A simple JUnit Jupiter extension that creates and starts a {@link MockWebServer}
+ * before <em>each</em> test, and shuts it down after <em>each</em> test.
+ */
 public class MockWebServerExtension implements BeforeEachCallback, AfterEachCallback {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
@@ -1,0 +1,9 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("MockWebServers")
+class MockWebServersTest {
+
+    // TODO
+}

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
@@ -1,9 +1,44 @@
 package org.kiwiproject.test.okhttp3.mockwebserver;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.io.KiwiIO;
+
+import java.io.IOException;
+import java.net.URI;
 
 @DisplayName("MockWebServers")
 class MockWebServersTest {
 
-    // TODO
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        KiwiIO.closeQuietly(server);
+    }
+
+    @Nested
+    class UriMethod {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "", "/", "/status", "/status/", "/users/active" })
+        void shouldCreateUri_WithPath(String path) {
+            var url = server.url(path).toString();
+            var expectedUri = URI.create(url);
+            assertThat(MockWebServers.uri(server, path)).isEqualTo(expectedUri);
+        }
+    }
 }

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
@@ -3,31 +3,26 @@ package org.kiwiproject.test.okhttp3.mockwebserver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.kiwiproject.io.KiwiIO;
 
-import java.io.IOException;
 import java.net.URI;
 
 @DisplayName("MockWebServers")
 class MockWebServersTest {
 
+    @RegisterExtension
+    private final MockWebServerExtension mockWebServerExtension = new MockWebServerExtension();
+
     private MockWebServer server;
 
     @BeforeEach
-    void setUp() throws IOException {
-        server = new MockWebServer();
-        server.start();
-    }
-
-    @AfterEach
-    void tearDown() {
-        KiwiIO.closeQuietly(server);
+    void setUp() {
+        server = mockWebServerExtension.server();
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -106,7 +106,6 @@ class RecordedRequestAssertionsTest {
                         .hasNoFailure()
                         .hasFailure(failure -> assertThat(failure).isNull())
                         .hasNoBody()
-                        .hasBodySize(0)
                         .hasHeader("Accept", "text/plain")
                         .hasRequestUrl(uri)
                         .hasRequestLine(f("GET {} HTTP/1.1", path))

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -21,16 +21,15 @@ import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.base.UncheckedInterruptedException;
-import org.kiwiproject.io.KiwiIO;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -47,22 +46,19 @@ import javax.net.ssl.SSLHandshakeException;
 @DisplayName("RecordedRequestAssertions")
 class RecordedRequestAssertionsTest {
 
+    @RegisterExtension
+    private final MockWebServerExtension mockWebServerExtension = new MockWebServerExtension();
+
     private MockWebServer server;
     private HttpClient httpClient;
 
     @BeforeEach
-    void setUp() throws IOException {
-        server = new MockWebServer();
-        server.start();
+    void setUp() {
+        server = mockWebServerExtension.server();
 
         httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofMillis(100))
                 .build();
-    }
-
-    @AfterEach
-    void tearDown() {
-        KiwiIO.closeQuietly(server);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -8,6 +8,10 @@ import static org.kiwiproject.base.KiwiStrings.f;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +28,6 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import okhttp3.mockwebserver.SocketPolicy;
 
 @DisplayName("RecordedRequestAssertions")
 class RecordedRequestAssertionsTest {
@@ -177,7 +176,9 @@ class RecordedRequestAssertionsTest {
         @Test
         void shouldCheckWhenHasBodyButNoneIsExpected() {
             server.enqueue(new MockResponse().setResponseCode(200));
-            JdkHttpClients.put(httpClient, uri(path), "{}");
+            JdkHttpClients.put(httpClient, uri(path), """
+                    { "foo": "bar" }
+                    """);
             recordedRequest = takeRequest();
 
             assertThatThrownBy(() -> RecordedRequestAssertions.assertThatRecordedRequest(recordedRequest).hasNoBody())

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -1,0 +1,447 @@
+package org.kiwiproject.test.okhttp3.mockwebserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.kiwiproject.base.KiwiStrings.f;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.base.UncheckedInterruptedException;
+import org.kiwiproject.io.KiwiIO;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+
+@DisplayName("RecordedRequestAssertions")
+class RecordedRequestAssertionsTest {
+
+    private MockWebServer server;
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(100))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        KiwiIO.closeQuietly(server);
+    }
+
+    @Test
+    void shouldCreateUsingAssertThat() throws InterruptedException {
+        server.enqueue(new MockResponse());
+
+        var path = "/";
+        JdkHttpClients.get(httpClient, uri(path));
+
+        var recordedRequest = takeRequest();
+
+        RecordedRequestAssertions.assertThat(recordedRequest)
+                .isGET()
+                .hasPath(path);
+    }
+
+    @Test
+    void shouldPassSuccessfulGETRequests() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/plain")
+                .setBody("Hello, world!")
+        );
+
+        var path = "/status";
+        var uri = uri(path);
+
+        JdkHttpClients.send(httpClient,  HttpRequest.newBuilder()
+                .GET()
+                .uri(uri)
+                .header("Accept", "text/plain")
+                .build());
+
+        var recordedRequest = takeRequest();
+
+        assertThatCode(() ->
+                    RecordedRequestAssertions.assertThatRecordedRequest(recordedRequest)
+                        .isGET()
+                        .isNotTls()
+                        .hasTlsVersion(null)
+                        .hasNoFailure()
+                        .hasFailure(failure -> assertThat(failure).isNull())
+                        .hasNoBody()
+                        .hasBodySize(0)
+                        .hasHeader("Accept", "text/plain")
+                        .hasRequestUrl(uri)
+                        .hasRequestLine(f("GET {} HTTP/1.1", path))
+                        .hasPath(path))
+                .doesNotThrowAnyException();
+    }
+
+    @Nested
+    class Bodies {
+
+        private String path;
+        private String body;
+        private RecordedRequest recordedRequest;
+
+        @BeforeEach
+        void setUp() {
+            path = "/users";
+            body = """
+                    {
+                        "username": "alice",
+                        "password": "peaches"
+                    }
+                    """;
+
+            server.enqueue(new MockResponse().setResponseCode(201));
+            JdkHttpClients.post(httpClient, uri(path), body);
+            recordedRequest = takeRequest();
+        }
+
+        @Test
+        void shouldCheckRequestBody() {
+            assertThatCode(() ->
+                        RecordedRequestAssertions.assertThatRecordedRequest(recordedRequest)
+                            .hasBodySize(body.length())
+                            .hasBody(body)
+                    ).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidBody() {
+            var expectedBody = """
+                {
+                    "username": "alice",
+                    "password": "hacked"
+                }
+                """;
+            assertThatThrownBy(() -> RecordedRequestAssertions.assertThat(recordedRequest) .hasBody(expectedBody))
+                    .isNotNull()
+                    .hasMessageContaining("Expected body as UTF-8 to be: " + expectedBody);
+        }
+
+        @Test
+        void shouldCheckInvalidBodySize() {
+            assertThatThrownBy(() -> RecordedRequestAssertions.assertThat(recordedRequest).hasBodySize(2_567))
+                    .isNotNull()
+                    .hasMessageContaining("Expected body size: 2567 byte");
+        }
+    }
+
+    @Nested
+    class NoBodies {
+
+        private String path;
+        private RecordedRequest recordedRequest;
+
+        @BeforeEach
+        void setUp() {
+            path = "/users/42";
+        }
+
+        @Test
+        void shouldCheckWhenExpectNoBody() {
+            server.enqueue(new MockResponse().setResponseCode(204));
+            JdkHttpClients.delete(httpClient, uri(path));
+            recordedRequest = takeRequest();
+
+            assertThatCode(() ->
+                        RecordedRequestAssertions.assertThatRecordedRequest(recordedRequest).hasNoBody()
+                    ).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckWhenHasBodyButNoneIsExpected() {
+            server.enqueue(new MockResponse().setResponseCode(200));
+            JdkHttpClients.put(httpClient, uri(path), "{}");
+            recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> RecordedRequestAssertions.assertThatRecordedRequest(recordedRequest).hasNoBody())
+                    .isNotNull()
+                    .hasMessageContaining("Expected there not to be a request body but found: {}");
+        }
+    }
+
+    @Nested
+    class RequestMethods {
+
+        @Test
+        void shouldCheckGETRequests() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/"));
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckPOSTRequests() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.post(httpClient, uri("/"), "{}");
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckPUTRequests() {
+            server.enqueue(new MockResponse());
+
+            JdkHttpClients.put(httpClient, uri("/"), "{}");
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckDELETERequests() {
+            server.enqueue(new MockResponse());
+
+            JdkHttpClients.delete(httpClient, uri("/"));
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckHEADRequests() {
+            server.enqueue(new MockResponse());
+
+            JdkHttpClients.send(httpClient, HttpRequest.newBuilder()
+                    .method("HEAD", BodyPublishers.noBody())
+                    .uri(uri("/"))
+                    .build());
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckOPTIONSRequests() {
+            server.enqueue(new MockResponse());
+
+            JdkHttpClients.send(httpClient, HttpRequest.newBuilder()
+                    .method("OPTIONS", BodyPublishers.noBody())
+                    .uri(uri("/"))
+                    .build());
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckCONNECTRequests() {
+            server.enqueue(new MockResponse());
+
+            // JDK HttpClient may not support CONNECT, so mock the RecordedRequest
+            var recordedRequest = mock(RecordedRequest.class);
+            when(recordedRequest.getMethod()).thenReturn("CONNECT");
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckTRACERequests() {
+            server.enqueue(new MockResponse());
+
+            JdkHttpClients.send(httpClient, HttpRequest.newBuilder()
+                    .method("TRACE", BodyPublishers.noBody())
+                    .uri(uri("/"))
+                    .build());
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH, "PATCH")
+            );
+        }
+
+        @Test
+        void shouldCheckPATCHRequests() {
+            server.enqueue(new MockResponse());
+
+            JdkHttpClients.send(httpClient, HttpRequest.newBuilder()
+                    .method("PATCH", BodyPublishers.ofString("{}"))
+                    .uri(uri("/"))
+                    .build());
+
+            var recordedRequest = takeRequest();
+
+            assertAll(
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isGET, "GET"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPOST, "POST"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isPUT, "PUT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isDELETE, "DELETE"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isHEAD, "HEAD"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isCONNECT, "CONNECT"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isOPTIONS, "OPTIONS"),
+                () -> assertNotExpectedMethod(recordedRequest, RecordedRequestAssertions::isTRACE, "TRACE"),
+                () -> assertExpectedMethod(recordedRequest, RecordedRequestAssertions::isPATCH)
+            );
+        }
+
+        private void assertExpectedMethod(RecordedRequest recordedRequest,
+                UnaryOperator<RecordedRequestAssertions> fn) {
+
+            var assertions = RecordedRequestAssertions.assertThat(recordedRequest);
+            assertThatCode(() -> fn.apply(assertions)).doesNotThrowAnyException();
+        }
+
+        private void assertNotExpectedMethod(RecordedRequest recordedRequest,
+                UnaryOperator<RecordedRequestAssertions> fn,
+                String method) {
+
+            var assertions = RecordedRequestAssertions.assertThat(recordedRequest);
+            assertThatThrownBy(() -> fn.apply(assertions))
+                    .isNotNull()
+                    .hasMessageContaining("Expected method to be " + method);
+        }
+    }
+
+    @Nested
+    class RequestFailures {
+
+        @Test
+        void shouldCheckFailureMessage() {
+            server.enqueue(new MockResponse()
+                    .throttleBody(1, 1, TimeUnit.SECONDS)
+                    .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_REQUEST_BODY));
+
+            String expectedMessage = null;
+            try {
+                JdkHttpClients.put(httpClient, uri("/"), "{}");
+            } catch (Exception e) {
+                expectedMessage = e.getCause().getMessage();
+            }
+
+            // TODO assert we have an expected message
+
+            var recordedRequest = takeRequest();
+
+            // TODO - why is the failure null?
+            //RecordedRequestAssertions.assertThat(recordedRequest).hasFailureMessage(expectedMessage);
+    }
+
+        // TODO
+    }
+
+    private RecordedRequest takeRequest() {
+        try {
+            return server.takeRequest(10, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new UncheckedInterruptedException(e);
+        }
+    }
+
+    private URI uri(String path) {
+        return MockWebServers.uri(server, path);
+    }
+}

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -575,6 +575,7 @@ class RecordedRequestAssertionsTest {
 
                 e.printStackTrace();
                 expectedMessage = e.getCause().getMessage();
+                System.out.println("expectedMessage = " + expectedMessage);
             }
 
             var theRecordedRequest = takeRequest();


### PR DESCRIPTION
* Add RecordedRequestAssertions and MockWebServerAssertions which provide
  fluent assertions for RecordedRequest and MockWebServer, respectively
* Add MockWebServers (extracted as separate utility, after I had done the same
  exact code multiple times)

Closes #493 
Closes #501 