### PR TITLE
Prepare for update to Mongo Java driver 5.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoDbExtensionTest.java
@@ -3,14 +3,12 @@ package org.kiwiproject.test.junit.jupiter;
 import static com.google.common.base.Verify.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.test.junit.jupiter.MongoDbExtensionTestHelpers.buildMongoTestProperties;
-import static org.kiwiproject.test.junit.jupiter.MongoDbExtensionTestHelpers.startInMemoryMongoServer;
+import static org.kiwiproject.test.junit.jupiter.MongoTestContainerHelpers.newMongoDBContainer;
 
 import com.mongodb.client.MongoClient;
-import de.bwaldvogel.mongo.MongoServer;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.bson.Document;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,26 +19,26 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.mongo.MongoTestProperties;
 import org.kiwiproject.test.mongo.MongoTestProperties.ServiceHostDomain;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @DisplayName("MongoDbExtension")
 @ExtendWith(SoftAssertionsExtension.class)
+@Testcontainers(disabledWithoutDocker = true)
 class MongoDbExtensionTest {
 
-    private MongoServer mongoServer;
+    @Container
+    static final MongoDBContainer MONGODB = newMongoDBContainer();
+
     private MongoTestProperties testProperties;
 
     @BeforeEach
     void setUp() {
-        mongoServer = startInMemoryMongoServer();
-        testProperties = buildMongoTestProperties(mongoServer.getLocalAddress());
-    }
-
-    @AfterEach
-    void tearDown() {
-        mongoServer.shutdownNow();
+        testProperties = buildMongoTestProperties(MONGODB);
     }
 
     @Test
@@ -274,7 +272,7 @@ class MongoDbExtensionTest {
 
             var databaseNames = MongoDbExtensionTestHelpers.databaseNames(mongoClient);
             assertThat(databaseNames)
-                    .containsExactlyInAnyOrder(customerDatabaseName, orderDatabaseName, marketingDatabaseName);
+                    .contains(customerDatabaseName, orderDatabaseName, marketingDatabaseName);
         }
 
         @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterAllTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterAllTest.java
@@ -14,11 +14,15 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.test.junit.jupiter.MongoServerExtension.DropTime;
 
 @DisplayName("MongoServerExtension: Drop Database @AfterAll")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIf(
+        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion7",
+        disabledReason = "Must support wire version 7 or higher")
 class MongoServerExtensionDropAfterAllTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterEachTest.java
@@ -14,11 +14,15 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.test.junit.jupiter.MongoServerExtension.DropTime;
 
 @DisplayName("MongoServerExtension: Drop Database @AfterEach")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIf(
+        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion7",
+        disabledReason = "Must support wire version 7 or higher")
 class MongoServerExtensionDropAfterEachTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
@@ -7,12 +7,16 @@ import de.bwaldvogel.mongo.ServerVersion;
 import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Map;
 import java.util.Optional;
 
 @DisplayName("MongoServerExtension")
+@EnabledIf(
+        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion7",
+        disabledReason = "Must support wire version 7 or higher")
 class MongoServerExtensionTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTestHelpers.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTestHelpers.java
@@ -4,15 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import de.bwaldvogel.mongo.ServerVersion;
 import lombok.experimental.UtilityClass;
 import org.bson.Document;
 
 import java.time.Instant;
+import java.util.Arrays;
 
 @UtilityClass
 class MongoServerExtensionTestHelpers {
 
     static final String TEST_COLLECTION_NAME = "testCollection";
+
+    static boolean anyServerVersionSupportsWireVersion7() {
+        return Arrays.stream(ServerVersion.values())
+                .anyMatch(serverVersion -> serverVersion.getWireVersion() > 6);
+    }
 
     static MongoCollection<Document> getTestCollection(MongoDatabase testDatabase) {
         return testDatabase.getCollection(TEST_COLLECTION_NAME);

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoTestContainerHelpers.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoTestContainerHelpers.java
@@ -1,0 +1,48 @@
+package org.kiwiproject.test.junit.jupiter;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.isNull;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+@UtilityClass
+@Slf4j
+public class MongoTestContainerHelpers {
+
+    public static final String ENV_MONGO_IMAGE_NAME = "MONGO_IMAGE_NAME";
+
+    public static final String MONGO_LATEST_IMAGE_NAME = "mongo:latest";
+
+    public static MongoDBContainer startedMongoDBContainer() {
+        var imageName = envMongoImageNameOrLatest();
+        return startedMongoDBContainer(imageName);
+    }
+
+    public static MongoDBContainer startedMongoDBContainer(String dockerImageName) {
+        var container = newMongoDBContainer(dockerImageName);
+        container.start();
+        checkState(container.isRunning());
+        return container;
+    }
+
+    public static MongoDBContainer newMongoDBContainer() {
+        var imageName = envMongoImageNameOrLatest();
+        return newMongoDBContainer(imageName);
+    }
+
+    private static String envMongoImageNameOrLatest() {
+        var envImageName = System.getenv(ENV_MONGO_IMAGE_NAME);
+        return isNull(envImageName) ? MONGO_LATEST_IMAGE_NAME : envImageName;
+    }
+
+    @SuppressWarnings("resource")  // because Testcontainers closes it for us
+    public static MongoDBContainer newMongoDBContainer(String dockerImageName) {
+        LOG.info("Create MongoDBContainer for Docker image name: {}", dockerImageName);
+        return new MongoDBContainer(DockerImageName.parse(dockerImageName))
+                .waitingFor(new HostPortWaitStrategy());
+    }
+}


### PR DESCRIPTION
* Refactor all the MongoDbExtension tests to use Testcontainers.
* Due to differences between Testcontainers and MongoServer in terms of when they create a database, change some assertions in the setUp and tearDown methods of the MongoDbExtension tests.
* Only enable the MongoServerExtension tests if any of the supported ServerVersion enum values has wire version 7 or higher.

Closes #522