### PR TITLE
Recorded Request improvements

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -30,7 +30,7 @@ public class RecordedRequestAssertions {
     private final RecordedRequest recordedRequest;
 
     private RecordedRequestAssertions(RecordedRequest recordedRequest) {
-        this.recordedRequest = requireNotNull(recordedRequest);
+        this.recordedRequest = requireNotNull(recordedRequest, "recordedRequest must not be null");
     }
 
     /**

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequests.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequests.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Contains test assertions for {@link RecordedRequest} when using {@link MockWebServer}.
+ * Contains utilities for working with {@link RecordedRequest} when using {@link MockWebServer}.
  */
 @UtilityClass
 @Slf4j

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.okhttp3.mockwebserver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.kiwiproject.base.KiwiStrings.f;
@@ -50,6 +51,19 @@ class RecordedRequestAssertionsTest {
         httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofMillis(100))
                 .build();
+    }
+
+    @Test
+    void shouldRequireNonNullRecordedRequest() {
+        assertAll(
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> RecordedRequestAssertions.assertThat(null).isGET())
+                        .withMessage("recordedRequest must not be null"),
+
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> RecordedRequestAssertions.assertThatRecordedRequest(null).isPOST())
+                        .withMessage("recordedRequest must not be null")
+        );
     }
 
     @Test


### PR DESCRIPTION
* Add a message to RecordedRequestAssertions null check to make it clear what is required without needing to go into the code.
* Make Javadoc in RecordedRequests clearer.