### PR TITLE
Fix misspelled property name in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
 
         <!-- This version must match the okhttp version in kiwi-bom. TODO: Consider adding this to kiwi-bom. -->
-        <ohttp3.mockwebserver.version>4.12.0</ohttp3.mockwebserver.version>
+        <okhttp3.mockwebserver.version>4.12.0</okhttp3.mockwebserver.version>
 
         <xmlunit.version>2.10.0</xmlunit.version>
 
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>${ohttp3.mockwebserver.version}</version>
+            <version>${okhttp3.mockwebserver.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Change all instances of 'ohttp' to 'okhttp'