### PR TITLE
Update mongo-java-server code to Mongo server 4.0, wire version 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- TODO Remove after updating kiwi-bom to 2.0.19 -->
+            <dependency>
+                <groupId>de.bwaldvogel</groupId>
+                <artifactId>mongo-java-server</artifactId>
+                <version>1.46.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>kiwi-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- TODO Remove after updating kiwi-bom to 2.0.19 -->
-            <dependency>
-                <groupId>de.bwaldvogel</groupId>
-                <artifactId>mongo-java-server</artifactId>
-                <version>1.46.0</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>kiwi-bom</artifactId>

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoServerExtension.java
@@ -20,12 +20,6 @@ import org.kiwiproject.test.mongo.MongoServerTests;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * <strong>WARNING:</strong> <em>As of kiwi-test 3.7.0, this extension will fail when using Mongo
- * driver version 5.2.0 or higher, as it requires minimum Mongo server 4.0 and wire version 7.
- * It will not work unless the <a href="https://github.com/bwaldvogel/mongo-java-server">mongo-java-server</a>
- * library fixes <a href="https://github.com/bwaldvogel/mongo-java-server/issues/233">this issue</a>
- * and creates a new release that supports wire version 7.</em>
- * <p>
  * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} that starts an in-memory
  * {@link MongoServer} once before all tests have run, and which shuts it down once after all tests have run.
  * An alternative for testing against "real" MongoDB instances is the {@link MongoDbExtension}.
@@ -40,8 +34,10 @@ import java.util.concurrent.ThreadLocalRandom;
  * to enable tests to get various objects such as the connection string, the test database name, a
  * {@link MongoDatabase} for the test database, a {@link MongoClient}, and more.
  * <p>
- * By default, the in-memory Mongo server will be set to the 3.6 flavor of Mongo.  If you need to use the 3.0 version of
- * Mongo, then the {@link ServerVersion} can be passed into the constructor to set the version.
+ * By default, the in-memory Mongo server will be set to the 4.0 flavor of Mongo.  If you need to use the 3.6 version of
+ * Mongo, then the {@link ServerVersion} can be passed into the constructor to set the version. You will also need
+ * to make sure you are using a Mongo driver version before 5.2.0, which changes to require Mongo server 4.0 and
+ * wire version 7.
  * <p>
  * Usage:
  * <pre>
@@ -65,7 +61,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @Slf4j
 public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback {
 
-    private static final ServerVersion DEFAULT_SERVER_VERSION = ServerVersion.MONGO_3_6;
+    private static final ServerVersion DEFAULT_SERVER_VERSION = ServerVersion.MONGO_4_0;
 
     /**
      * The in-memory {@link MongoServer} instance started by this extension.
@@ -123,7 +119,7 @@ public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback
     /**
      * Creates a new instance that will drop and re-create the test database after each test.
      * <p>
-     * The Mongo server will be set to the 3.6 version
+     * The Mongo server will be set to the 4.0 version
      */
     public MongoServerExtension() {
         this(DropTime.AFTER_EACH, DEFAULT_SERVER_VERSION);
@@ -132,7 +128,7 @@ public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback
     /**
      * Creates a new instance that will drop the test database using the given {@link DropTime}.
      * <p>
-     * The Mongo server will be set to the 3.6 version
+     * The Mongo server will be set to the 4.0 version
      *
      * @param dropTime when to drop the test database
      */

--- a/src/main/java/org/kiwiproject/test/mongo/MongoServerTests.java
+++ b/src/main/java/org/kiwiproject/test/mongo/MongoServerTests.java
@@ -16,12 +16,12 @@ public class MongoServerTests {
     /**
      * Start a new in-memory {@link MongoServer}.
      * <p>
-     * Defaults server version to Mongo 3.6
+     * Defaults server version to Mongo 4.0
      *
      * @return the started MongoServer instance
      */
     public static MongoServer startInMemoryMongoServer() {
-        return startInMemoryMongoServer(ServerVersion.MONGO_3_6);
+        return startInMemoryMongoServer(ServerVersion.MONGO_4_0);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
@@ -79,8 +79,8 @@ class MongoServerExtensionTest {
     }
 
     @Test
-    void shouldCreateServerExtensionWithDefaultMongo3_6() {
+    void shouldCreateServerExtensionWithDefaultMongo4_0() {
         var extension = new MongoServerExtension();
-        assertThat(extension.getServerVersion()).isEqualTo(ServerVersion.MONGO_3_6);
+        assertThat(extension.getServerVersion()).isEqualTo(ServerVersion.MONGO_4_0);
     }
 }


### PR DESCRIPTION
* Update MongoServerExtension to use ServerVersion.MONGO_4_0 as the default, so that it can work with Mongo driver 5.2.0 and higher versions.
* Update MongoServerTests to use ServerVersion.MONGO_4_0 as the default in the no-args startInMemoryMongoServer().
* Update Javadocs in MongoServerExtension and MongoServerTests.
* Lock the required version of mongo-java-server to 1.46.0 in the POM until kiwi-bom 2.0.19 is released.

Closes #539