### PR TITLE
Add the ability to get base URI from MockWebServerExtension

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -14,6 +14,7 @@ import org.kiwiproject.io.KiwiIO;
 import org.kiwiproject.util.function.KiwiConsumers;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.function.Consumer;
 
 /**
@@ -22,9 +23,21 @@ import java.util.function.Consumer;
  */
 public class MockWebServerExtension implements BeforeEachCallback, AfterEachCallback {
 
+    /**
+     * The {@link MockWebServer} started by this extension.
+     */
     @Getter
     @Accessors(fluent = true)
     private final MockWebServer server;
+
+    /**
+     * The base {@link URI} of the {@link MockWebServer}.
+     * <p>
+     * This is available after the {@link MockWebServer} has been started.
+     */
+    @Getter
+    @Accessors(fluent = true)
+    private URI uri;
 
     private final Consumer<MockWebServer> serverCustomizer;
 
@@ -57,6 +70,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
     public void beforeEach(ExtensionContext context) throws IOException {
         serverCustomizer.accept(server);
         server.start();
+        uri = MockWebServers.uri(server);
     }
 
     @Override


### PR DESCRIPTION
* Add a uri() method to MockWebServerExtension that returns the base URI of the started MockWebServer
* Initialize the base URI in the BeforeEach method
* Add Javadoc to the server field/method

Closes #555