### PR TITLE
Add the ability to get a relative URI from MockWebServerExtension

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -77,4 +77,17 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
     public void afterEach(ExtensionContext context) {
         KiwiIO.closeQuietly(server);
     }
+
+    /**
+     * Get a {@link URI} with the give {@code path} that can be used to
+     * make calls to the {@link MockWebServer}.
+     * <p>
+     * This can be called after the {@link MockWebServer} has been started.
+     *
+     * @param path the path
+     * @return a new {@link URI}
+     */
+    public URI uri(String path) {
+        return uri.resolve(path);
+    }
 }

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 
@@ -42,8 +41,7 @@ class MockWebServerAssertionsTest {
         server.enqueue(new MockResponse());
 
         var path = "/status";
-        var url = server.url(path).toString();
-        var uri = URI.create(url);
+        var uri = mockWebServerExtension.uri(path);
         JdkHttpClients.get(httpClient, uri);
 
         assertThatCode(() ->
@@ -61,13 +59,11 @@ class MockWebServerAssertionsTest {
         server.enqueue(new MockResponse().setResponseCode(201));
 
         var path1 = "/status";
-        var url1 = server.url(path1).toString();
-        var uri1 = URI.create(url1);
+        var uri1 = mockWebServerExtension.uri(path1);
         JdkHttpClients.get(httpClient, uri1);
 
         var path2 = "/create";
-        var url2 = server.url(path2).toString();
-        var uri2 = URI.create(url2);
+        var uri2 = mockWebServerExtension.uri(path2);
         var body = """
                     { "name": "Bob" }
                     """;

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -656,6 +656,6 @@ class RecordedRequestAssertionsTest {
     }
 
     private URI uri(String path) {
-        return MockWebServers.uri(server, path);
+        return mockWebServerExtension.uri(path);
     }
 }

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestsTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.base.UncheckedInterruptedException;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
@@ -173,8 +172,7 @@ class RecordedRequestsTest {
                 .connectTimeout(Duration.ofMillis(100))
                 .build();
 
-        var url = server.url(path).toString();
-        var uri = URI.create(url);
+        var uri = mockWebServerExtension.uri(path);
 
         try {
             var request = HttpRequest.newBuilder().GET().uri(uri).build();


### PR DESCRIPTION
* Add a uri(String path) method to MockWebServerExtension. It returns a URI for the path argument that is relative to the base URI of the started MockWebServer.
* Refactor several tests to use the new method.

Closes #556