### PR TITLE
Add MockWebServerExtension constructor that accepts a server customizer

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -56,7 +56,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
      * use the builder instead of this constructor.
      */
     public MockWebServerExtension() {
-        this(new MockWebServer(), KiwiConsumers.noOp());
+        this(KiwiConsumers.noOp());
     }
 
     /**

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -60,6 +60,17 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
     }
 
     /**
+     * Create a new instance that will create a new {@link MockWebServer} and
+     * customize it using the {@code serverCustomizer}.
+     *
+     * @param serverCustomizer allows a test to configure the server, e.g., to customize the protocols
+     *                         it supports or to serve requests via HTTPS over TLS. Must not be {@code null}.
+     */
+    public MockWebServerExtension(Consumer<MockWebServer> serverCustomizer) {
+        this(new MockWebServer(), requireNotNull(serverCustomizer, "serverCustomizer must not be null"));
+    }
+
+    /**
      * Create a new instance that will use the given {@link MockWebServer} and customizer.
      *
      * @param server           the server

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
@@ -30,7 +30,29 @@ import java.util.function.Consumer;
 class MockWebServerExtensionTest {
 
     @Nested
-    class Constructors {
+    class NoArgsConstructor {
+
+        @Test
+        void shouldCreateServer() {
+            var extension = new MockWebServerExtension();
+
+            assertThat(extension.server()).isNotNull();
+        }
+    }
+
+    @Nested
+    class ConstructorWithServerCustomizer {
+
+        @Test
+        void shouldRequireNonNullCustomizer() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new MockWebServerExtension(null))
+                    .withMessage("serverCustomizer must not be null");
+        }
+    }
+
+    @Nested
+    class AllArgsConstructor {
 
         @Test
         void shouldRequireNonNullServer() {
@@ -45,13 +67,6 @@ class MockWebServerExtensionTest {
             var server = new MockWebServer();
             assertThatCode(() -> new MockWebServerExtension(server, null))
                     .doesNotThrowAnyException();
-        }
-
-        @Test
-        void shouldCreateServer() {
-            var extension = new MockWebServerExtension();
-
-            assertThat(extension.server()).isNotNull();
         }
 
         @Test


### PR DESCRIPTION
* Add one-arg constructor that accepts a Consumer<MockWebServer>.
* Throw IllegalArgumentException if the serverCustomizer argument is null.
* Reorganize the constructor tests and add new test for new constructor.

Related to #547, #555, #556