### PR TITLE
Add RandomStringSource and RandomStringArgumentsProvider

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProvider.java
@@ -1,0 +1,162 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.CountStrategy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * An {@link ArgumentsProvider} that provides random strings. Accepts a {@link RandomStringSource}
+ * which provides the various options for generating the random strings.
+ */
+public class RandomStringArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<RandomStringSource> {
+
+    private RandomStringSource randomStringSource;
+
+    @Override
+    public void accept(RandomStringSource randomStringSource) {
+        this.randomStringSource = randomStringSource;
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        checkArgument(randomStringSource.minLength() <= randomStringSource.maxLength(),
+                "minLength must be equal or less than maxLength");
+
+        var prefix = randomStringSource.prefix();
+        var suffix = randomStringSource.suffix();
+        var randomGenerator = getRandomStringGenerator();
+        var stringSupplier = randomSupplier(randomGenerator);
+        var argumentCount = getNumberToGenerate();
+
+        return Stream.generate(stringSupplier)
+                .map(s -> isNotBlank(prefix) ? prefix + s : s)
+                .map(s -> isNotBlank(suffix) ? s + suffix : s)
+                .map(Arguments::of)
+                .limit(argumentCount);
+    }
+
+    @SuppressWarnings("java:S2245")  // suppress: Using pseudorandom number generators (PRNGs) is security-sensitive
+    private RandomStringUtils getRandomStringGenerator() {
+        return useSecureRandom() ? RandomStringUtils.secure() : RandomStringUtils.insecure();
+    }
+
+    private Supplier<String> randomSupplier(RandomStringUtils randomGenerator) {
+        var minLengthInclusive = randomStringSource.minLength();
+        var maxLengthExclusive = 1 + randomStringSource.maxLength();
+
+        return switch (randomStringSource.stringType()) {
+            case ALPHABETIC -> () -> randomGenerator.nextAlphabetic(minLengthInclusive, maxLengthExclusive);
+            case ALPHANUMERIC -> () -> randomGenerator.nextAlphanumeric(minLengthInclusive, maxLengthExclusive);
+            case ASCII -> () -> randomGenerator.nextAscii(minLengthInclusive, maxLengthExclusive);
+            case CHARS -> () -> charsStringSupplier(randomGenerator, minLengthInclusive, maxLengthExclusive);
+            case CHAR_RANGE -> charRangeStringSupplier(randomGenerator, minLengthInclusive, maxLengthExclusive);
+            case CHAR_RANGES -> charRangesStringSupplier(randomGenerator, minLengthInclusive, maxLengthExclusive);
+            case GRAPH -> () -> randomGenerator.nextGraph(minLengthInclusive, maxLengthExclusive);
+            case NUMERIC -> () -> randomGenerator.nextNumeric(minLengthInclusive, maxLengthExclusive);
+            case PRINT -> () -> randomGenerator.nextPrint(minLengthInclusive, maxLengthExclusive);
+        };
+    }
+
+    private String charsStringSupplier(RandomStringUtils randomGenerator,
+                                       int minLengthInclusive,
+                                       int maxLengthExclusive) {
+
+        checkArgument(randomStringSource.chars().length > 0, "chars must have at least one character");
+        var length = getRandomUtils().randomInt(minLengthInclusive, maxLengthExclusive);
+        return randomGenerator.next(length, randomStringSource.chars());
+    }
+
+    private Supplier<String> charRangeStringSupplier(RandomStringUtils randomGenerator,
+                                                     int minLengthInclusive,
+                                                     int maxLengthExclusive) {
+
+        checkArgument(randomStringSource.endChar() > randomStringSource.beginChar(),
+                "endChar must be higher than beginChar");
+
+        var chars = newCharArray(randomStringSource.beginChar(), randomStringSource.endChar());
+        return () -> {
+            var length = getRandomUtils().randomInt(minLengthInclusive, maxLengthExclusive);
+            return randomGenerator.next(length, chars);
+        };
+    }
+
+    private Supplier<String> charRangesStringSupplier(RandomStringUtils randomGenerator,
+                                                      int minLengthInclusive,
+                                                      int maxLengthExclusive) {
+
+        var beginChars = randomStringSource.beginChars();
+        var endChars = randomStringSource.endChars();
+        checkArgument(beginChars.length == endChars.length, "beginChars and endChars must have the same length");
+
+        var charArrayList = new ArrayList<char[]>(beginChars.length);
+
+        for (var i = 0; i < beginChars.length; i++) {
+            var beginChar = beginChars[i];
+            var endChar = endChars[i];
+            var chars = newCharArray(beginChar, endChar);
+            charArrayList.add(chars);
+        }
+
+        var allChars = combineCharArrays(charArrayList);
+        return () -> {
+            var length = getRandomUtils().randomInt(minLengthInclusive, maxLengthExclusive);
+            return randomGenerator.next(length, allChars);
+        };
+    }
+
+    private static char[] newCharArray(char beginChar, char endChar) {
+        var size = endChar - beginChar + 1;
+        var charArray = new char[size];
+
+        for (int i = 0; i < size; i++) {
+            charArray[i] = (char) (beginChar + i);
+        }
+        return charArray;
+    }
+
+    private static char[] combineCharArrays(List<char[]> charArrays) {
+        var totalLength = charArrays.stream().mapToInt(arr -> arr.length).sum();
+        var result = new char[totalLength];
+
+        var destPos = 0;
+        for (var charArray : charArrays) {
+            System.arraycopy(charArray, 0, result, destPos, charArray.length);
+            destPos += charArray.length;
+        }
+        return result;
+    }
+
+    private int getNumberToGenerate() {
+        if (randomStringSource.countStrategy() == CountStrategy.FIXED) {
+            checkArgument(randomStringSource.count() > 0, "count must be greater than zero");
+            return randomStringSource.count();
+        }
+
+        checkArgument(randomStringSource.minCount() > 0 && randomStringSource.maxCount() >= randomStringSource.minCount(),
+                "minCount must be greater than zero, and maxCount must be greater or equal to minCount");
+        var minInclusive = randomStringSource.minCount();
+        var maxExclusive = 1 + randomStringSource.maxCount();
+        return getRandomUtils().randomInt(minInclusive, maxExclusive);
+    }
+
+    @SuppressWarnings("java:S2245")  // suppress: Using pseudorandom number generators (PRNGs) is security-sensitive
+    private RandomUtils getRandomUtils() {
+        return useSecureRandom() ? RandomUtils.secure() : RandomUtils.insecure();
+    }
+
+    private boolean useSecureRandom() {
+        return randomStringSource.randomSecurity().isSecure();
+    }
+}

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringSource.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringSource.java
@@ -1,0 +1,235 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An {@link ArgumentsSource} that provides random strings to parameterized tests.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ArgumentsSource(RandomStringArgumentsProvider.class)
+public @interface RandomStringSource {
+
+    /**
+     * The minimum length that a generated argument will have.
+     */
+    int minLength() default 5;
+
+    /**
+     * The maximum length that a generated argument will have.
+     */
+    int maxLength() default 20;
+
+    /**
+     * A prefix that will be prepended to each argument.
+     */
+    String prefix() default "";
+
+    /**
+     * A suffix that will be appended to each argument.
+     */
+    String suffix() default "";
+
+    /**
+     * Controls the type of characters that the generated strings contain.
+     * <p>
+     * Depending on the type, you can specify additional properties that
+     * control, for example, the range of characters to include.
+     */
+    StringType stringType() default StringType.ALPHANUMERIC;
+
+    /**
+     * Defines whether the PRNG used to generate random strings is
+     * cryptographically strong.
+     */
+    RandomSecurity randomSecurity() default RandomSecurity.INSECURE;
+
+    /**
+     * Defines a fixed number of arguments to generate.
+     * <p>
+     * Use with {@link CountStrategy#FIXED}.
+     */
+    int count() default 10;
+
+    /**
+     * Defines a minimum number of arguments to generate.
+     * <p>
+     * Use with {@link CountStrategy#RANDOM}.
+     */
+    int minCount() default 1;
+
+    /**
+     * Defines a maximum number of arguments to generate.
+     * <p>
+     * Use with {@link CountStrategy#RANDOM}.
+     */
+    int maxCount() default 10;
+
+    /**
+     * Defines the specific characters that a random string may contain.
+     * <p>
+     * Use with {@link StringType#CHARS}.
+     */
+    char[] chars() default {
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+    };
+
+    /**
+     * Defines the beginning character in a range that defines the
+     * specific characters that a random string may contain.
+     * <p>
+     * Use with {@link StringType#CHAR_RANGE}.
+     */
+    char beginChar() default 'a';
+
+    /**
+     * Defines the ending character in a range that defines the
+     * specific characters that a random string may contain.
+     * <p>
+     * Use with {@link StringType#CHAR_RANGE}.
+     */
+    char endChar() default 'z';
+
+    /**
+     * Defines the beginning characters of one or more ranges that define the
+     * specific characters that a random string may contain.
+     * <p>
+     * Use with {@link StringType#CHAR_RANGES}.
+     */
+    char[] beginChars() default { 'a', 'A', '0' };
+
+    /**
+     * Defines the ending characters of one or more ranges that define the
+     * specific characters that a random string may contain.
+     * <p>
+     * Use with {@link StringType#CHAR_RANGES}.
+     */
+    char[] endChars() default { 'z', 'Z', '9' };
+
+    /**
+     * The strategy that determines the number of arguments to provide.
+     */
+    CountStrategy countStrategy() default CountStrategy.FIXED;
+
+    /**
+     * Defines whether to generate a fixed or variable number of arguments.
+     */
+    enum CountStrategy {
+
+        /**
+         * Generate a fixed number of arguments.
+         */
+        FIXED,
+
+        /**
+         * Generate a random number of arguments between a minimum and maximum.
+         */
+        RANDOM
+    }
+
+    /**
+     * Defines the types of characters to include in the random strings.
+     */
+    enum StringType {
+
+        /**
+         * Characters from Latin alphabetic characters (a-z, A-Z) will be used.
+         */
+        ALPHABETIC,
+
+        /**
+         * Characters from Latin alphabetic characters (a-z, A-Z) and the digits 0-9 will be used.
+         */
+        ALPHANUMERIC,
+
+        /**
+         * Characters from the ASCII character set with values between 32 and 126 (inclusive) will be used.
+         */
+        ASCII,
+
+        /**
+         * A specific set of user-specified characters.
+         *
+         * @see #chars()
+         */
+        CHARS,
+
+        /**
+         * Characters in a user-specified range.
+         *
+         * @see #beginChar()
+         * @see #endChar()
+         */
+        CHAR_RANGE,
+
+        /**
+         * Characters in one or more user-specified ranges.
+         * <p>
+         * The ranges are defined using {@link #beginChars()} and {@link #endChars()}
+         * at corresponding indexes.
+         * <p>
+         * For example, if {@code beginChars} is {@code ['a', t', '4']} and {@code endChars}
+         * is {@code ['d', 'v', '7']} then the overall set of characters contains
+         * {@code 'a'} through {@code 'd'}, {@code 't'} through {@code 'v'}, and
+         * {@code '4'} through {@code '7'}. The ranges are inclusive, so the beginning
+         * and ending characters are included.
+         *
+         * @see #beginChars()
+         * @see #endChars()
+         */
+        CHAR_RANGES,
+
+        /**
+         * Characters matching the {@code POSIX [:graph:]} regular expression character class.
+         * This set of characters contains all visible ASCII characters (i.e., all ASCII
+         * characters except spaces and control characters).
+         */
+        GRAPH,
+
+        /**
+         * Characters include the digits 0-9.
+         */
+        NUMERIC,
+
+        /**
+         * Characters matching the {@code POSIX [:print:]} regular expression character class.
+         * This set of characters contains all visible ASCII characters and spaces (but no
+         * control characters).
+         */
+        PRINT
+    }
+
+    /**
+     * Controls whether a cryptographically strong PRNG is used to generate random characters.
+     */
+    enum RandomSecurity {
+
+        /**
+         * Random strings are generated using a cryptographically strong PRNG
+         * such as {@link java.security.SecureRandom}.
+         */
+        SECURE,
+
+        /**
+         * Random strings are generated using a PRNG that is not cryptographically
+         * strong, such as {@link java.util.concurrent.ThreadLocalRandom}.
+         * <p>
+         * For unit tests, this will almost always be enough. It will also
+         * be, in general, significantly faster when generating large numbers
+         * of arguments.
+         */
+        INSECURE;
+
+        public boolean isSecure() {
+            return this == SECURE;
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
@@ -1,0 +1,451 @@
+package org.kiwiproject.test.junit.jupiter.params.provider;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.CharUtils.isAscii;
+import static org.apache.commons.lang3.CharUtils.isAsciiAlpha;
+import static org.apache.commons.lang3.CharUtils.isAsciiAlphanumeric;
+import static org.apache.commons.lang3.CharUtils.isAsciiPrintable;
+import static org.apache.commons.lang3.StringUtils.containsOnly;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.params.IntRangeSource;
+import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.CountStrategy;
+import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.RandomSecurity;
+import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.StringType;
+
+import java.lang.annotation.Annotation;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+@DisplayName("RandomStringArgumentsProvider")
+@Slf4j
+class RandomStringArgumentsProviderTest {
+
+    @ParameterizedTest
+    @RandomStringSource(randomSecurity = RandomSecurity.SECURE)
+    void shouldProvideStrings_UsingSecureRandom(String s) {
+        assertThat(s).isNotBlank();
+    }
+
+    /**
+     * This is NOT intended as a test of the Java PRNGs but rather to
+     * verify that the argument provider is using a PRNG at all.
+     * <p>
+     * Plus, it was interesting coming up with this pseudo-test with the help of ChatGPT.
+     * Though, I only skimmed some sources it gave me, such as
+     * <a href="https://en.wikipedia.org/wiki/Pseudorandom_number_generator">Pseudorandom number generator</a>,
+     * <a href="https://math.stackexchange.com/questions/72223/finding-expected-number-of-distinct-values-selected-from-a-set-of-integers">Finding expected number of distinct values selected from a set of integers</a>,
+     * and <a href="https://www.randomservices.org/random/urn/Birthday.html">The Birthday Problem</a>.
+     * <p>
+     * When writing this test, I observed that, for higher number of arguments generated,
+     * the secure random PRNG is significantly slower. For example, on my M2 MacBook Pro
+     * this test takes about 10-11 milliseconds to generate 50,000 alphanumeric arguments
+     * between 5 and 10 characters long using an insecure PRNG, while it consistently takes
+     * between 550 and 600 milliseconds for the secure PRNG! Interestingly, I did not
+     * observe significant differences in the number of unique numbers generated, but
+     * that is most likely because this "test" is not realistic and generates only a
+     * limited number of random values. Also, these observations are NOT meant to imply
+     * that the insecure PRNG generates random values that are just as "good" as the secure one.
+     */
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            10, INSECURE, 2, 2
+            10, SECURE, 2, 2
+            20, INSECURE, 5, 15
+            20, SECURE, 5, 15
+            1000, INSECURE, 3, 3
+            1000, SECURE, 3, 3
+            2000, INSECURE, 3, 3
+            2000, SECURE, 3, 3
+            3000, INSECURE, 3, 3
+            3000, SECURE, 3, 3
+            5000, INSECURE, 5, 5
+            5000, SECURE, 5, 5
+            5000, INSECURE, 5, 10
+            5000, SECURE, 5, 10
+            50000, INSECURE, 5, 5
+            100000, INSECURE, 5, 5
+            """)
+    void shouldEnsureNonDeterministicValues(int argumentCount,
+                                            RandomSecurity security,
+                                            int minLength,
+                                            int maxLength) {
+
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .randomSecurity(security)
+                .minLength(minLength)
+                .maxLength(maxLength)
+                .count(argumentCount)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        var values = provider.provideArguments(null)
+                .map(Arguments::get)
+                .flatMap(Arrays::stream)
+                .map(String.class::cast)
+                .limit(argumentCount)
+                .collect(toSet());
+
+        var minimumPercentUnique = 0.98;
+        var expectedMinUnique = (int) (minimumPercentUnique * argumentCount);
+        var numUniqueValues = values.size();
+        var percentUnique = numUniqueValues / (double) argumentCount;
+
+        var percentInstance = NumberFormat.getPercentInstance(Locale.ENGLISH);
+        percentInstance.setMinimumFractionDigits(2);
+
+        LOG.debug("argument count = {}", argumentCount);
+        LOG.debug("num unique values = {}", numUniqueValues);
+        LOG.debug("num duplicate values = {}", (argumentCount - numUniqueValues));
+        LOG.debug("% unique values = {}", percentInstance.format(percentUnique));
+        LOG.debug("minimum allowed unique values = {} ({})",
+                expectedMinUnique, percentInstance.format(minimumPercentUnique));
+
+        assertThat(values)
+                .describedAs("Got %d (%s) unique values but expected a minimum of %d",
+                        numUniqueValues,
+                        percentInstance.format(percentUnique),
+                        expectedMinUnique)
+                .hasSizeGreaterThan(expectedMinUnique);
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(count = 50)
+    void shouldProvideStrings_BetweenDefaultMinAndMax(String s) {
+        assertThat(s.length())
+                .isGreaterThanOrEqualTo(5)
+                .isLessThanOrEqualTo(20);
+    }
+
+    @ParameterizedTest
+    @IntRangeSource(from = -10, to = 0, closed = true)
+    void shouldThrowIllegalArgumentException_IfCountIsNotPositive(int count) {
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .count(count)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("count must be greater than zero");
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(count = 25, minLength = 2, maxLength = 8)
+    void shouldProvideStrings_BetweenCustomMinAndMax(String s) {
+        assertThat(s.length())
+                .isGreaterThanOrEqualTo(2)
+                .isLessThanOrEqualTo(8);
+    }
+
+    @RepeatedTest(10)
+    void shouldThrowIllegalArgumentException_IfMinLengthGreaterThanMaxLength() {
+        var minLength = ThreadLocalRandom.current().nextInt(1, 10);
+        var maxLength = minLength - 1;
+
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .minLength(minLength)
+                .maxLength(maxLength)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("minLength must be equal or less than maxLength");
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(prefix = "test-")
+    void shouldProvideStrings_WithPrefix(String s) {
+        assertThat(s).startsWith("test-");
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(suffix = "-service")
+    void shouldProvideStrings_WithSuffix(String s) {
+        assertThat(s).endsWith("-service");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 5, 10, 25, 35 })
+    void shouldProduceFixedNumberOfValues(int count) {
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .count(count)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        var arguments = provider.provideArguments(null)
+                .map(Arguments::get)
+                .flatMap(Arrays::stream)
+                .map(String.class::cast)
+                .toArray();
+
+        assertThat(arguments).hasSize(count);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            1, 10
+            5, 15
+            5, 5
+            10, 20
+            5, 30
+            10, 50
+            """)
+    void shouldProduceRandomNumberOfValues(int minCount, int maxCount) {
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .minCount(minCount)
+                .maxCount(maxCount)
+                .countStrategy(CountStrategy.RANDOM)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        var arguments = provider.provideArguments(null)
+                .map(Arguments::get)
+                .flatMap(Arrays::stream)
+                .map(String.class::cast)
+                .toArray();
+
+        assertThat(arguments).hasSizeBetween(minCount, maxCount);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 10
+            0, 15
+            5, 4
+            10, 9
+            35, 30
+            20, 10
+            """)
+    void shouldThrowIllegalArgumentException_IfInvalidMinAndMaxCount(int minCount, int maxCount) {
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .minCount(minCount)
+                .maxCount(maxCount)
+                .countStrategy(CountStrategy.RANDOM)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("minCount must be greater than zero, and maxCount must be greater or equal to minCount");
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.ALPHABETIC)
+    void shouldProduceStrings_WithOnly_AlphabeticCharacters(String s) {
+        s.chars().forEach(ch -> assertThat(isAsciiAlpha((char) ch)).isTrue());
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.ALPHANUMERIC)
+    void shouldProduceStrings_WithOnly_AlphanumericCharacters(String s) {
+        s.chars().forEach(ch -> assertThat(isAsciiAlphanumeric((char) ch)).isTrue());
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.ASCII)
+    void shouldProduceStrings_WithOnly_AsciiCharacters(String s) {
+        s.chars().forEach(ch -> assertThat(isAscii((char) ch)).isTrue());
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.GRAPH)
+    void shouldProduceStrings_WithOnly_GraphCharacters(String s) {
+        var validChars = IntStream.rangeClosed(33, 126)
+                .mapToObj(i -> String.valueOf((char) i))
+                .collect(joining())
+                .toCharArray();
+
+        assertThat(containsOnly(s, validChars)).isTrue();
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.NUMERIC)
+    void shouldProduceStrings_WithOnly_NumericCharacters(String s) {
+        assertThat(s).containsOnlyDigits();
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.PRINT)
+    void shouldProduceStrings_WithOnly_PrintCharacters(String s) {
+        s.chars().forEach(ch -> assertThat(isAsciiPrintable((char) ch)).isTrue());
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.CHARS, chars = { 'a', 'b', 'x', 'y', 'z' })
+    void shouldProduceStrings_WithSpecificChars(String s) {
+        assertThat(containsOnly(s, 'a', 'b', 'x', 'y', 'z')).isTrue();
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentException_IfCharsIsEmpty() {
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .stringType(StringType.CHARS)
+                .chars(new char[0])
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        // we need to force the stream to terminate for this test
+        //noinspection ResultOfMethodCallIgnored
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null).toList())
+                .withMessage("chars must have at least one character");
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.CHAR_RANGE, beginChar = 't', endChar = 'x')
+    void shouldProduceStrings_WithinCharRange(String s) {
+        assertThat(containsOnly(s, 't', 'u', 'v', 'w', 'x', 'y', 'z')).isTrue();
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.CHAR_RANGE,
+            beginChar = 't', endChar = 'x',
+            randomSecurity = RandomSecurity.SECURE)
+    void shouldProduceStrings_WithinCharRange_UsingSecureRandom(String s) {
+        assertThat(containsOnly(s, 't', 'u', 'v', 'w', 'x', 'y', 'z')).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            d, c
+            z, a
+            f, b
+            """)
+    void shouldThrowIllegalArgumentException_IfBeginCharIsGreaterThanEndChar(char beginChar, char endChar) {
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .stringType(StringType.CHAR_RANGE)
+                .beginChar(beginChar)
+                .endChar(endChar)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("endChar must be higher than beginChar");
+    }
+
+    @ParameterizedTest
+    @RandomStringSource(stringType = StringType.CHAR_RANGES,
+            beginChars = { 'j', 'J', '5' },
+            endChars = { 'p', 'P', '8' })
+    void shouldProduceStrings_WithinCharRanges(String s) {
+        var validChars = new char[] {
+                'j', 'k', 'l', 'm', 'n', 'o', 'p',
+                'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                '5', '6', '7', '8'
+        };
+
+        assertThat(containsOnly(s, validChars)).isTrue();
+    }
+
+    @RepeatedTest(10)
+    void shouldThrowIllegalArgumentException_IfBeginCharsLengthDoesNotMatchEndCharsLength() {
+        var beginCharCount = ThreadLocalRandom.current().nextInt(5, 11);
+        var beginChars = new char[beginCharCount];
+
+        var randomVal = ThreadLocalRandom.current().nextInt(-3, 4);
+        var diff = (randomVal == 0) ? 1 : randomVal;  // the diff can't be zero!
+        var endChars = new char[beginCharCount + diff];
+
+        var randomStringSource = RandomStringSourceForTesting.builder()
+                .stringType(StringType.CHAR_RANGES)
+                .beginChars(beginChars)
+                .endChars(endChars)
+                .build();
+
+        var provider = createAndInitProvider(randomStringSource);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> provider.provideArguments(null))
+                .withMessage("beginChars and endChars must have the same length");
+    }
+
+    private static RandomStringArgumentsProvider createAndInitProvider(RandomStringSource randomStringSource) {
+        var provider = new RandomStringArgumentsProvider();
+        provider.accept(randomStringSource);
+        return provider;
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    @Builder
+    @Getter
+    @Accessors(fluent = true)
+    static class RandomStringSourceForTesting implements RandomStringSource {
+
+        @Builder.Default
+        int minLength = 5;
+
+        @Builder.Default
+        int maxLength = 20;
+
+        @Builder.Default
+        String prefix = "";
+
+        @Builder.Default
+        String suffix = "";
+
+        @Builder.Default
+        StringType stringType = StringType.ALPHANUMERIC;
+
+        @Builder.Default
+        RandomSecurity randomSecurity = RandomSecurity.INSECURE;
+
+        @Builder.Default
+        int count = 5;
+
+        @Builder.Default
+        int minCount = 1;
+
+        @Builder.Default
+        int maxCount = 10;
+
+        @Builder.Default
+        char[] chars = { 'a', 'b', 'c', 'd', 'e' };
+
+        @Builder.Default
+        char beginChar = 'a';
+
+        @Builder.Default
+        char endChar = 'e';
+
+        @Builder.Default
+        char[] beginChars = { 'a', '1' };
+
+        @Builder.Default
+        char[] endChars = { 'e', '5' };
+
+        @Builder.Default
+        CountStrategy countStrategy = CountStrategy.FIXED;
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return RandomStringSource.class;
+        }
+    }
+}


### PR DESCRIPTION
* Add annotation RandomStringSource, which is an ArgumentsSource to provide random strings for parameterized JUnit tests.
* Add RandomStringArgumentsProvider, which is the ArgumentsProvider implementation that produces random strings within the constraints described by RandomStringSource.

Closes #564