### PR TITLE
Change root logger to WARN level in logback-test.xml

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -34,7 +34,7 @@
         <appender-ref ref="LogbackTestHelpersIntegrationTestAppender"/>
     </logger>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 


### PR DESCRIPTION
There's no reason we need all that extra logging at INFO level. Running the tests locally, the number of log lines went from 4817 down to 3490, a savings of 1327 lines.

The last test run in GH actions for JDK 21 had 4854 log lines.