### PR TITLE
Update MongoServerExtension tests to require wire version 8

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoServerExtension.java
@@ -34,10 +34,14 @@ import java.util.concurrent.ThreadLocalRandom;
  * to enable tests to get various objects such as the connection string, the test database name, a
  * {@link MongoDatabase} for the test database, a {@link MongoClient}, and more.
  * <p>
- * By default, the in-memory Mongo server will be set to the 4.0 flavor of Mongo.  If you need to use the 3.6 version of
- * Mongo, then the {@link ServerVersion} can be passed into the constructor to set the version. You will also need
- * to make sure you are using a Mongo driver version before 5.2.0, which changes to require Mongo server 4.0 and
- * wire version 7.
+ * <strong>Warning about Mongo versions</strong>
+ * <p>
+ * By default, the in-memory Mongo server will be set to the 4.0 flavor of Mongo. This requires a Mongo driver
+ * that supports wire version 7. If you need to use the 3.6 version of Mongo, then the {@link ServerVersion} can be
+ * passed into the constructor to set the version. You will also need to make sure you are using a Mongo driver
+ * version before 5.2.0, which changes to require Mongo server 4.0 and wire version 7. If you are using a Mongo
+ * driver that supports a higher wire version, then this extension will not work. Wire version 8 started
+ * in Mongo 4.2, and Mongo driver 5.5.0 and higher requires that wire version.
  * <p>
  * Usage:
  * <pre>

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterAllTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterAllTest.java
@@ -21,8 +21,8 @@ import org.kiwiproject.test.junit.jupiter.MongoServerExtension.DropTime;
 @DisplayName("MongoServerExtension: Drop Database @AfterAll")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @EnabledIf(
-        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion7",
-        disabledReason = "Must support wire version 7 or higher")
+        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion8",
+        disabledReason = "Must support wire version 8 or higher")
 class MongoServerExtensionDropAfterAllTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterEachTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionDropAfterEachTest.java
@@ -21,8 +21,8 @@ import org.kiwiproject.test.junit.jupiter.MongoServerExtension.DropTime;
 @DisplayName("MongoServerExtension: Drop Database @AfterEach")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @EnabledIf(
-        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion7",
-        disabledReason = "Must support wire version 7 or higher")
+        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion8",
+        disabledReason = "Must support wire version 8 or higher")
 class MongoServerExtensionDropAfterEachTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTest.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 
 @DisplayName("MongoServerExtension")
 @EnabledIf(
-        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion7",
-        disabledReason = "Must support wire version 7 or higher")
+        value = "org.kiwiproject.test.junit.jupiter.MongoServerExtensionTestHelpers#anyServerVersionSupportsWireVersion8",
+        disabledReason = "Must support wire version 8 or higher")
 class MongoServerExtensionTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTestHelpers.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/MongoServerExtensionTestHelpers.java
@@ -16,9 +16,9 @@ class MongoServerExtensionTestHelpers {
 
     static final String TEST_COLLECTION_NAME = "testCollection";
 
-    static boolean anyServerVersionSupportsWireVersion7() {
+    static boolean anyServerVersionSupportsWireVersion8() {
         return Arrays.stream(ServerVersion.values())
-                .anyMatch(serverVersion -> serverVersion.getWireVersion() > 6);
+                .anyMatch(serverVersion -> serverVersion.getWireVersion() == 8);
     }
 
     static MongoCollection<Document> getTestCollection(MongoDatabase testDatabase) {


### PR DESCRIPTION
Mongo driver 5.5.0 requires wire version 8, so change the tests for MongoServerExtension to require that wire version. Once we update to kiwi-bom 2.0.25, the tests will fail without this change.