### PR TITLE
Fix deprecated API usage in JUnit extensions

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
@@ -5,6 +5,7 @@ import static java.util.Collections.unmodifiableList;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -68,7 +69,7 @@ public class AsciiOnlyBlankStringArgumentsProvider implements ArgumentsProvider 
      * exhausted. So don't do that.
      */
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         return ASCII_ONLY_BLANK_STRINGS.stream().map(Arguments::of);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProvider.java
@@ -5,6 +5,7 @@ import static java.util.Collections.unmodifiableList;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -98,7 +99,7 @@ public class BlankStringArgumentsProvider implements ArgumentsProvider {
      * exhausted. So don't do that.
      */
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         return BLANK_STRINGS.stream().map(Arguments::of);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProvider.java
@@ -5,6 +5,7 @@ import static java.util.Collections.unmodifiableList;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +40,7 @@ public class MinimalBlankStringArgumentsProvider implements ArgumentsProvider {
     );
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         return BLANK_STRINGS.stream().map(Arguments::of);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -26,7 +27,7 @@ class RandomDoubleArgumentsProvider implements ArgumentsProvider, AnnotationCons
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         checkArgument(randomDoubleSource.min() <= randomDoubleSource.max(), "min must be equal or less than max");
 
         var random = ThreadLocalRandom.current();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProvider.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -35,7 +36,7 @@ class RandomIntArgumentsProvider implements ArgumentsProvider, AnnotationConsume
      * {@link ThreadLocalRandom#nextInt(int, int)}.
      */
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         checkArgument(randomIntSource.min() <= randomIntSource.max(), "min must be equal or less than max");
 
         var random = ThreadLocalRandom.current();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProvider.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -26,7 +27,7 @@ class RandomLongArgumentsProvider implements ArgumentsProvider, AnnotationConsum
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         checkArgument(randomLongSource.min() <= randomLongSource.max(), "min must be equal or less than max");
 
         var random = ThreadLocalRandom.current();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProvider.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.CountStrategy;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ public class RandomStringArgumentsProvider implements ArgumentsProvider, Annotat
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
         checkArgument(randomStringSource.minLength() <= randomStringSource.maxLength(),
                 "minLength must be equal or less than maxLength");
 

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
@@ -26,7 +26,7 @@ class RandomDoubleArgumentsProviderTest {
         provider.accept(randomDoubleSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("min must be equal or less than max");
     }
 
@@ -40,7 +40,7 @@ class RandomDoubleArgumentsProviderTest {
         var provider = new RandomDoubleArgumentsProvider();
         provider.accept(randomDoubleSource);
 
-        var arguments = provider.provideArguments(null)
+        var arguments = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToDouble(value -> (double) value)
@@ -63,7 +63,7 @@ class RandomDoubleArgumentsProviderTest {
         var provider = new RandomDoubleArgumentsProvider();
         provider.accept(randomDoubleSource);
 
-        var arguments = provider.provideArguments(null)
+        var arguments = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToDouble(value -> (double) value)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
@@ -22,7 +22,7 @@ class RandomIntArgumentsProviderTest {
         provider.accept(randomIntSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("min must be equal or less than max");
     }
 
@@ -33,7 +33,7 @@ class RandomIntArgumentsProviderTest {
         var provider = new RandomIntArgumentsProvider();
         provider.accept(randomIntSource);
 
-        var arguments = provider.provideArguments(null)
+        var arguments = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToInt(value -> (int) value)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
@@ -21,7 +21,7 @@ class RandomLongArgumentsProviderTest {
         provider.accept(randomLongSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("min must be equal or less than max");
     }
 
@@ -32,7 +32,7 @@ class RandomLongArgumentsProviderTest {
         var provider = new RandomLongArgumentsProvider();
         provider.accept(randomLongSource);
 
-        var arguments = provider.provideArguments(null)
+        var arguments = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToLong(value -> (long) value)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
@@ -96,7 +96,7 @@ class RandomStringArgumentsProviderTest {
 
         var provider = createAndInitProvider(randomStringSource);
 
-        var values = provider.provideArguments(null)
+        var values = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .map(String.class::cast)
@@ -144,7 +144,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("count must be greater than zero");
     }
 
@@ -169,7 +169,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("minLength must be equal or less than maxLength");
     }
 
@@ -194,7 +194,7 @@ class RandomStringArgumentsProviderTest {
 
         var provider = createAndInitProvider(randomStringSource);
 
-        var arguments = provider.provideArguments(null)
+        var arguments = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .map(String.class::cast)
@@ -221,7 +221,7 @@ class RandomStringArgumentsProviderTest {
 
         var provider = createAndInitProvider(randomStringSource);
 
-        var arguments = provider.provideArguments(null)
+        var arguments = provider.provideArguments(null, null)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .map(String.class::cast)
@@ -249,7 +249,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("minCount must be greater than zero, and maxCount must be greater or equal to minCount");
     }
 
@@ -312,7 +312,7 @@ class RandomStringArgumentsProviderTest {
         // we need to force the stream to terminate for this test
         //noinspection ResultOfMethodCallIgnored
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null).toList())
+                .isThrownBy(() -> provider.provideArguments(null, null).toList())
                 .withMessage("chars must have at least one character");
     }
 
@@ -346,7 +346,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("endChar must be higher than beginChar");
     }
 
@@ -382,7 +382,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null))
+                .isThrownBy(() -> provider.provideArguments(null, null))
                 .withMessage("beginChars and endChars must have the same length");
     }
 


### PR DESCRIPTION
JUnit 5.13 deprecated the original provideArguments method.

Replace that with the new method which accepts two arguments,
a ParameterDeclarations and ExtensionContext.