### PR TITLE
Update ResetLogbackLoggingExtension docs with crucial information

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -21,37 +21,59 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
  * extensions both stop and detach all appenders after all tests complete! Both of those extensions
  * reset Logback in
  * <a href="https://github.com/dropwizard/dropwizard/blob/297870e3b4b43ea9fb19417dd90ed78151cf6f5d/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L244">DropwizardTestSupport</a>.
- * Once this happens, there is no logging output from later tests (since there are no more appenders).
+ * Once this happens, there is <em>no logging output</em> from later tests (since there are no more appenders).
  * We consider this to be <em>bad</em>, since logging output is useful to track down causes if
  * there are other test failures. And, it's just not nice behavior to completely hijack logging!
  * <p>
  * You can use this extension in tests that are using misbehaving components to ensure that Logback
  * is reset after all tests complete, so that later tests have log output.
  * <p>
+ * <strong>It is <em>very</em> important that this extension is registered <em>before</em> extensions
+ * like {@code DropwizardExtensionsSupport} that also manipulate Logback. By registering it
+ * before the other extensions, the {@code beforeAll} executes first, but the {@code afterAll}
+ * executes <em>last</em>.</strong>
+ * <p>
+ * By executing this extension's {@code afterAll} last, we can guarantee to reset Logback logging.
+ * Otherwise, the reset by this extension will be undone by the reset performed by
+ * {@code DropwizardExtensionsSupport} (or similar).
+ * <p>
  * For example, to use the default {@code logback-test.xml} as the logging configuration you
- * can just use {@code @ExtendWith} on the test class:
+ * can use {@code @ExtendWith} on the test class:
  * <pre>
+ *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class)  // register first
  *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
- *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class)
- *   class CustomClientTest {
+ *   class SomeTest {
  *
- *       // test code that uses DropwizardClientExtension
+ *       // test code that uses DropwizardClientExtension or DropwizardAppExtension
  *   }
  * </pre>
  * Alternatively, you can register the extension programmatically to use a custom
- * logging configuration:
+ * logging configuration. When doing this, you must register {@code DropwizardExtensionsSupport}
+ * and similar extensions programmatically as well to ensure the correct order using
+ * JUnit's {@link org.junit.jupiter.api.Order Order} annotation.
  * <pre>
- *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
- *   class CustomClientTest {
+ *   class AnotherTest {
  *
+ *      {@literal @}Order(1)
  *      {@literal @}RegisterExtension
  *       static final ResetLogbackLoggingExtension RESET_LOGBACK = ResetLogbackLoggingExtension.builder()
  *               .logbackConfigFilePath("acme-special-logback.xml")
  *               .build();
  *
- *       // test code that uses DropwizardClientExtension
+ *      {@literal @}Order(2)
+ *      {@literal @}RegisterExtension
+ *       static final DropwizardExtensionsSupport DW_SUPPORT = new DropwizardExtensionsSupport();
+ *
+ *       // test code that uses DropwizardClientExtension or DropwizardAppExtension
  *   }
  * </pre>
+ * You can <em>not</em> register a static {@code ResetLogbackLoggingExtension} programmatically and
+ * register {@code DropwizardExtensionsSupport} (or similar) using {@code @ExtendWith} at
+ * the class level due to JUnit's ordering rules. See
+ * <a href="https://docs.junit.org/current/user-guide/#extensions-registration-programmatic">Programmatic Extension Registration</a>
+ * in the JUnit reference manual. To be sure of the extension order when using programmatic
+ * registration, use explicit {@code @Order} annotations. It's also more clear and does not require
+ * remembering the registration order or the differences between static and instance fields.
  */
 @Builder
 @NoArgsConstructor


### PR DESCRIPTION
Update ResetLogbackLoggingExtension Javadocs with important information about extension ordering and update the examples to register in the correct order.

Closes #587