### PR TITLE
Fix the order of ResetLogbackLoggingExtension in kiwi-test's tests

### DIFF
--- a/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/DropwizardAppTestsTest.java
@@ -13,7 +13,6 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import lombok.AllArgsConstructor;
@@ -26,14 +25,13 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
+import org.kiwiproject.test.junit.jupiter.DropwizardExtensionsSupportWithLoggingReset;
 
 import java.util.List;
 
 @DisplayName("DropwizardAppTests")
 @ExtendWith(SoftAssertionsExtension.class)
-@ExtendWith(DropwizardExtensionsSupport.class)
-@ExtendWith(ResetLogbackLoggingExtension.class)
+@DropwizardExtensionsSupportWithLoggingReset
 class DropwizardAppTestsTest {
 
     @Getter

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionConfigOverridesTest.java
@@ -53,6 +53,8 @@ class PostgresAppTestExtensionConfigOverridesTest {
         }
     }
 
+    // Do NOT annotate this with RegisterExtension.
+    // This test executes the extension programmatically.
     private static final PostgresAppTestExtension<Config> EXTENSION = new PostgresAppTestExtension<>(
             "PostgresAppTestExtensionTest/test-migrations.xml",
             "PostgresAppTestExtensionTest/test-config.yml",

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionCustomPropertyTest.java
@@ -43,6 +43,8 @@ class PostgresAppTestExtensionCustomPropertyTest {
         }
     }
 
+    // Do NOT annotate this with RegisterExtension.
+    // This test executes the extension programmatically.
     private static final PostgresAppTestExtension<Config> EXTENSION = new PostgresAppTestExtension<>(
             "PostgresAppTestExtensionTest/test-migrations.xml",
             "PostgresAppTestExtensionTest/test-config.yml",

--- a/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtensionTest.java
@@ -40,6 +40,8 @@ class PostgresAppTestExtensionTest {
         }
     }
 
+    // Do NOT annotate this with RegisterExtension.
+    // This test executes the extension programmatically.
     private static final PostgresAppTestExtension<Config> EXTENSION = new PostgresAppTestExtension<>(
             "PostgresAppTestExtensionTest/test-migrations.xml",
             "PostgresAppTestExtensionTest/test-config.yml",

--- a/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/test/logback/LogbackTestHelpersIntegrationTest.java
@@ -10,7 +10,6 @@ import io.dropwizard.core.Application;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,8 +18,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
+import org.kiwiproject.test.junit.jupiter.DropwizardExtensionsSupportWithLoggingReset;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -41,8 +39,7 @@ import org.slf4j.LoggerFactory;
  * is therefore a bit circular.
  */
 @DisplayName("LogbackTestHelpers (Integration Test)")
-@ExtendWith(DropwizardExtensionsSupport.class)
-@ExtendWith(ResetLogbackLoggingExtension.class)
+@DropwizardExtensionsSupportWithLoggingReset
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Slf4j
 class LogbackTestHelpersIntegrationTest {


### PR DESCRIPTION
* Use DropwizardExtensionsSupportWithLoggingReset in DropwizardAppTestsTest and LogbackTestHelpersIntegrationTest to ensure correct order. They've been in the WRONG order for quite a while now!
* Add comments in several PostgresAppTestExtension tests explaining that the PostgresAppTestExtension field should NOT be annotated with RegisterExtension (as it normally would be) because the tests are calling the JUnit extension lifecycle methods.

Closes #591