### PR TITLE
Replace usage of implicit commons-collections4 dependency

### DIFF
--- a/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
+++ b/src/main/java/org/kiwiproject/test/logback/LogbackTestHelpers.java
@@ -11,13 +11,13 @@ import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import com.google.common.io.Resources;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.collections4.ListUtils;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Static test utilities that provide Logback-related functionality.
@@ -72,10 +72,10 @@ public class LogbackTestHelpers {
     }
 
     private static URL getFirstLogbackConfigOrThrow(String logbackConfigFilePath, String... fallbackConfigFilePaths) {
-        var allConfigs = ListUtils.union(
-                List.of(logbackConfigFilePath),
-                List.of(fallbackConfigFilePaths)
-        );
+        var allConfigs = Stream.concat(
+                Stream.of(logbackConfigFilePath),
+                Arrays.stream(fallbackConfigFilePaths)
+        ).toList();
 
         return allConfigs.stream()
                 .map(LogbackTestHelpers::getResourceOrNull)


### PR DESCRIPTION
* Modify LogbackTestHelpers#getFirstLogbackConfigOrThrow to use only JDK classes and not depend on ListUtils from commons-collections4.
* The code looks very similar, changing to use Stream#concat instead of ListUtils#union, and to use Stream#of and Arrays#stream rather than List#of. And add #toList to convert the Stream to a List so that the remainder of the code works as is.

Closes #593