### PR TITLE
Add 'resourceExtensionFor' to DropwizardResourceTests

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTests.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTests.java
@@ -1,5 +1,7 @@
 package org.kiwiproject.test.dropwizard.resource;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import io.dropwizard.testing.junit5.ResourceExtension;
 import lombok.experimental.UtilityClass;
 
@@ -10,14 +12,38 @@ import lombok.experimental.UtilityClass;
 public class DropwizardResourceTests {
 
     /**
+     * Create a {@link ResourceExtension} for the given Jakarta REST {@code resource} instance.
+     * <p>
+     * This is useful when you don't need complex configuration and only need to
+     * create the extension for a single resource instance.
+     * <p>
+     * <strong>Note:</strong> The returned extension preserves the existing Logback
+     * configuration by disabling the logging bootstrap.
+     *
+     * @param resource the Jakarta REST resource instance
+     * @return a new {@link ResourceExtension} instance
+     * @see #resourceBuilderPreservingLogbackConfig()
+     */
+    public static ResourceExtension resourceExtensionFor(Object resource) {
+        checkArgumentNotNull(resource, "resource must not be null");
+        return resourceBuilderPreservingLogbackConfig()
+                .addResource(resource)
+                .build();
+    }
+
+    /**
      * Create a {@link ResourceExtension} builder that preserves the existing Logback
-     * configuration by disabling the logging boostrap.
+     * configuration by disabling the logging bootstrap.
      * <p>
      * Tired of writing {@code ResourceExtension.builder().bootstrapLogging(false)}
      * every time you create a {@link ResourceExtension}? Then use this absurdly
      * simple method to avoid boilerplate.
+     * <p>
+     * If you need to preserve the logging configuration, and you only need to
+     * add a single resource, you can use {@link #resourceExtensionFor(Object)}.
      *
      * @return a new {@link ResourceExtension.Builder} instance
+     * @see #resourceExtensionFor(Object)
      * @see ResourceExtension.Builder#bootstrapLogging(boolean)
      */
     public static ResourceExtension.Builder resourceBuilderPreservingLogbackConfig() {

--- a/src/test/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTestsTest.java
@@ -1,17 +1,109 @@
 package org.kiwiproject.test.dropwizard.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.collect.KiwiLists.hasOneElement;
 import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
+import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.test.junit.jupiter.ClearBoxTest;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 
-@DisplayName("DropwizardResource")
+@DisplayName("DropwizardResourceTests")
 class DropwizardResourceTestsTest {
+
+    // Logback sentinel added BEFORE building the ResourceExtension ---
+    private static final LoggerContext LOGBACK_CTX = (LoggerContext) LoggerFactory.getILoggerFactory();
+    private static final Logger ROOT_LOGBACK_LOGGER = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    private static final ListAppender<ILoggingEvent> SENTINEL = new ListAppender<>();
+
+    static {
+        SENTINEL.setName("KIWI_SENTINEL");
+        SENTINEL.setContext(LOGBACK_CTX);
+        SENTINEL.start();
+        ROOT_LOGBACK_LOGGER.addAppender(SENTINEL);
+    }
+
+    @Path("/test")
+    public static class MyTestResource {
+        @GET
+        public Response hello() {
+            return Response.ok("hello").build();
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        ROOT_LOGBACK_LOGGER.detachAppender(SENTINEL);
+        SENTINEL.stop();
+    }
+
+    @Nested
+    @ExtendWith(DropwizardExtensionsSupport.class)
+    class ResourceExtensionFor {
+
+        private static final ResourceExtension RESOURCES =
+                DropwizardResourceTests.resourceExtensionFor(new MyTestResource());
+
+        @Test
+        void shouldCreateRegisteredResource() {
+            var response = RESOURCES.target("/test").request().get();
+
+            assertAll(
+                    () -> assertOkResponse(response),
+                    () -> assertThat(response.readEntity(String.class)).isEqualTo("hello"));
+        }
+
+        @Test
+        void shouldNotAllowNullResourceObject() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> DropwizardResourceTests.resourceExtensionFor(null))
+                    .withMessage("resource must not be null");
+        }
+
+        @Test
+        void shouldPreserveLogbackConfigurationByNotBootstrappingLogging() {
+            var stillThere = ROOT_LOGBACK_LOGGER.getAppender("KIWI_SENTINEL");
+            assertThat(stillThere)
+                    .describedAs("Sentinel appender should remain attached; if this assertion fails, " +
+                            "Dropwizard likely bootstrapped logging and reset Logback (which detaches appenders).")
+                    .isSameAs(SENTINEL);
+
+            SENTINEL.list.clear();
+            var marker = MarkerFactory.getMarker("KIWI_SENTINEL_MARKER");
+            var logMessage = "kiwi sentinel check";
+            ROOT_LOGBACK_LOGGER.warn(marker, logMessage);  // root logger is at WARN level, so must be that level or higher
+            assertThat(SENTINEL.list)
+                    .describedAs("Expected exactly one WARN message with marker '%s' captured by sentinel; logger=%s, root level=%s. " +
+                                    "If empty, Dropwizard likely bootstrapped logging and reset Logback (detaching appenders). " +
+                                    "If size != 1, unrelated WARN logs may have been captured.",
+                            marker.getName(), ROOT_LOGBACK_LOGGER.getName(), ROOT_LOGBACK_LOGGER.getLevel())
+                    .filteredOn(event -> {
+                        var markers = event.getMarkerList();
+                        return hasOneElement(markers) && first(markers).equals(marker);
+                    })
+                    .extracting(ILoggingEvent::getFormattedMessage)
+                    .containsExactly(logMessage);
+        }
+    }
 
     @Nested
     class ResourceBuilderPreservingLogbackConfig {

--- a/src/test/java/org/kiwiproject/test/jaxrs/RequestResponseLoggerTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/RequestResponseLoggerTest.java
@@ -3,7 +3,7 @@ package org.kiwiproject.test.jaxrs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
-import static org.kiwiproject.test.dropwizard.resource.DropwizardResourceTests.resourceBuilderPreservingLogbackConfig;
+import static org.kiwiproject.test.dropwizard.resource.DropwizardResourceTests.resourceExtensionFor;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
@@ -51,9 +51,7 @@ class RequestResponseLoggerTest {
         }
     }
 
-    private static final ResourceExtension RESOURCES = resourceBuilderPreservingLogbackConfig()
-            .addResource(new RequestResponseLoggerTestResource())
-            .build();
+    private static final ResourceExtension RESOURCES = resourceExtensionFor(new RequestResponseLoggerTestResource());
 
     private Client client;
     private SimpleTestLogHandler handler;

--- a/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
+++ b/src/test/java/org/kiwiproject/test/jaxrs/exception/JaxrsExceptionTestHelperTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.kiwiproject.test.dropwizard.resource.DropwizardResourceTests.resourceBuilderPreservingLogbackConfig;
+import static org.kiwiproject.test.dropwizard.resource.DropwizardResourceTests.resourceExtensionFor;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
@@ -108,9 +108,7 @@ class JaxrsExceptionTestHelperTest {
     @ExtendWith(DropwizardExtensionsSupport.class)
     class ToJaxrsExceptionInboundResponse {
 
-        private final ResourceExtension resources = resourceBuilderPreservingLogbackConfig()
-                .addResource(new ResourceForInboundResponseTests())
-                .build();
+        private static final ResourceExtension resources = resourceExtensionFor(new ResourceForInboundResponseTests());
 
         private Client client;
 


### PR DESCRIPTION
This method preserves the Logback logging configuration and is a one-liner when you only need to use a single resource object, i.e., addResource(new myResource()).

Update JaxrsExceptionTestHelperTest and RequestResponseLoggerTest to use DropwizardResourceTests#resourceExtensionFor.

Closes #601