### PR TITLE
Enhance/clarify Javadocs in several JUnit extensions

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
@@ -46,7 +46,7 @@ import org.postgresql.Driver;
  *          Since this uses {@link DropwizardAppExtension}, the Logback configuration is reset to a minimal
  *          configuration or completely wiped out. When using this, consider also using the
  *          {@link org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension ResetLogbackLoggingExtension},
- *          so that the original Logback configuration is retained after the test. To use the reset extension,
+ *          so that the original Logback configuration is restored after the test. To use the reset extension,
  *          you can add {@code @ExtendWith(ResetLogbackLoggingExtension.class} to the test class.
  *      </li>
  * </ul>

--- a/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
@@ -42,6 +42,13 @@ import org.postgresql.Driver;
  *          You should <strong>not</strong> register {@code DropwizardExtensionsSupport} or the embedded Postgres
  *          extension. See the WARNING below.
  *      </li>
+ *      <li>
+ *          Since this uses {@link DropwizardAppExtension}, the Logback configuration is reset to a minimal
+ *          configuration or completely wiped out. When using this, consider also using the
+ *          {@link org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension ResetLogbackLoggingExtension},
+ *          so that the original Logback configuration is retained after the test. To use the reset extension,
+ *          you can add {@code @ExtendWith(ResetLogbackLoggingExtension.class} to the test class.
+ *      </li>
  * </ul>
  * <p>
  * To include this extension in an Application test, add the following at the top of the class:

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.test.junit.jupiter;
 
+import ch.qos.logback.classic.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,9 +22,11 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
  * extensions both stop and detach all appenders after all tests complete! Both of those extensions
  * reset Logback in
  * <a href="https://github.com/dropwizard/dropwizard/blob/297870e3b4b43ea9fb19417dd90ed78151cf6f5d/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L244">DropwizardTestSupport</a>.
- * Once this happens, there is <em>no logging output</em> from later tests (since there are no more appenders).
- * We consider this to be <em>bad</em>, since logging output is useful to track down causes if
- * there are other test failures. And, it's just not nice behavior to completely hijack logging!
+ * Once this happens, there is either a minimal configuration that only logs at {@code INFO} and higher levels,
+ * or worse, there is <em>no logging output</em> from later tests (in the case where it calls
+ * {@link Logger#detachAndStopAllAppenders()}). We consider this to be <em>bad</em>, since logging output is
+ * useful to track down causes if there are other test failures. And, it's just not nice behavior to completely
+ * hijack logging!
  * <p>
  * You can use this extension in tests that are using misbehaving components to ensure that Logback
  * is reset after all tests complete, so that later tests have log output.

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.test.junit.jupiter;
 
-import ch.qos.logback.classic.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,10 +22,10 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
  * reset Logback in
  * <a href="https://github.com/dropwizard/dropwizard/blob/297870e3b4b43ea9fb19417dd90ed78151cf6f5d/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L244">DropwizardTestSupport</a>.
  * Once this happens, there is either a minimal configuration that only logs at {@code INFO} and higher levels,
- * or worse, there is <em>no logging output</em> from later tests (in the case where it calls
- * {@link Logger#detachAndStopAllAppenders()}). We consider this to be <em>bad</em>, since logging output is
- * useful to track down causes if there are other test failures. And, it's just not nice behavior to completely
- * hijack logging!
+ * or worse, there is <em>no logging output</em> from later tests (in the case where it calls Logback's
+ * {@link ch.qos.logback.classic.Logger#detachAndStopAllAppenders() Logger#detachAndStopAllAppenders()}.
+ * We consider this to be <em>bad</em>, since logging output is useful to track down causes if there are
+ * other test failures. And, it's just not nice behavior to completely hijack logging!
  * <p>
  * You can use this extension in tests that are using misbehaving components to ensure that Logback
  * is reset after all tests complete, so that later tests have log output.


### PR DESCRIPTION
* Update PostgresAppTestExtension Javadocs to note that the logging configuration will be reset, and that ResetLogbackLoggingExtension can be used to restore it after all tests run.
* Update ResetLogbackLoggingExtension Javadocs with more clarity on when the logging configuration is completely wiped out versus reset to a "sane default" configuration (according to Dropwizard, anyway) that only logs at INFO level and above.