### PR TITLE
Security: Use Use full commit SHA hash for flagged GitHub actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
 
     - name: Delombok
-      uses: sleberknight/delombok-action@v0.8.0
+      uses: sleberknight/delombok-action@56a7f9d35ad110b4c85e400353c355124f476c08
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/print-delomboked-sources.yml
+++ b/.github/workflows/print-delomboked-sources.yml
@@ -25,7 +25,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2        
         
       - name: Run Delombok
-        uses: sleberknight/delombok-action@v0.8.0
+        uses: sleberknight/delombok-action@56a7f9d35ad110b4c85e400353c355124f476c08
         
       - name: Print the Delomboked code
-        uses: sleberknight/print-delombok@v0.7.0
+        uses: sleberknight/print-delombok@13bf5860ede3e769a836dda7804df9e08a685e55

--- a/.github/workflows/update-license-copyright-years.yml
+++ b/.github/workflows/update-license-copyright-years.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v3
+      - uses: FantasticFiasco/action-update-license-year@d837fc83ecb71196807bdf3854208f556e66f6ed
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: LICENSE.txt


### PR DESCRIPTION
* Change sleberknight/delombok-action to use full commit hash
* Change sleberknight/print-delombok to use full commit hash
* Change FantasticFiasco/action-update-license-year to use full commit hash