### PR TITLE
Add conventional commits prefix to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       - "sleberknight"
       - "chrisrohr"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -30,3 +32,5 @@ updates:
     assignees:
       - "sleberknight"
       - "chrisrohr"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
- Add `commit-message: prefix: "chore(deps)"` to Dependabot configuration for conventional commits support

🤖 Generated with [Claude Code](https://claude.com/claude-code)