### PR TITLE
chore(deps): override transitive BouncyCastle deps to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,9 @@
         <!-- Versions for test dependencies -->
         <memoryfilesystem.version>2.8.2</memoryfilesystem.version>
 
+        <!-- Override transitive BouncyCastle version from netty-pkitesting -->
+        <bouncycastle.version>1.84</bouncycastle.version>
+
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_kiwi-test</sonar.projectKey>
         <sonar.organization>kiwiproject</sonar.organization>
@@ -65,6 +68,24 @@
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jakarta.persistence-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Override the transitive BouncyCastle dependencies (bcpkix-jdk18on,
bcprov-jdk18on, bcutil-jdk18on) introduced via netty-pkitesting to
version 1.84, which addresses CVE-2026-5588.