### PR TITLE
Add hasHeaderValueStartingWith and hasHeaderValueContaining to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -250,6 +250,38 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * starts with the given prefix.
+     *
+     * @param name   the HTTP header name
+     * @param prefix the expected prefix of the HTTP header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderValueStartingWith(String name, String prefix) {
+        Assertions.assertThat(recordedRequest.getHeader(name))
+                .describedAs("Expected %s header to have value starting with: %s", name, prefix)
+                .startsWith(prefix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * contains the given substring.
+     *
+     * @param name      the HTTP header name
+     * @param substring the expected substring of the HTTP header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderValueContaining(String name, String substring) {
+        Assertions.assertThat(recordedRequest.getHeader(name))
+                .describedAs("Expected %s header to have value containing: %s", name, substring)
+                .contains(substring);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request does not have a request body.
      * <p>
      * Only DELETE, PATCH, POST, and PUT may have a body.

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -252,6 +252,38 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * starts with the given prefix.
+     *
+     * @param name   the HTTP header name
+     * @param prefix the expected prefix of the HTTP header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderValueStartingWith(String name, String prefix) {
+        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+                .describedAs("Expected %s header to have value starting with: %s", name, prefix)
+                .startsWith(prefix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * contains the given substring.
+     *
+     * @param name      the HTTP header name
+     * @param substring the expected substring of the HTTP header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderValueContaining(String name, String substring) {
+        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+                .describedAs("Expected %s header to have value containing: %s", name, substring)
+                .contains(substring);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request does not have a request body.
      * <p>
      * Only DELETE, PATCH, POST, and PUT may have a body.

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -37,7 +37,7 @@ import java.util.function.UnaryOperator;
 
 import javax.net.ssl.SSLHandshakeException;
 
-@DisplayName("RecordedRequestAssertions")
+@DisplayName("RecordedRequestAssertions (mockwebserver)")
 class RecordedRequestAssertionsTest {
 
     @RegisterExtension
@@ -516,6 +516,68 @@ class RecordedRequestAssertionsTest {
             assertThatThrownBy(() -> fn.apply(assertions))
                     .isNotNull()
                     .hasMessageContaining("Expected method to be " + method);
+        }
+    }
+
+    @Nested
+    class Headers {
+
+        private RecordedRequest recordedRequest;
+
+        @BeforeEach
+        void setUp() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.send(httpClient, HttpRequest.newBuilder()
+                    .GET()
+                    .uri(uri("/"))
+                    .header("Accept", "text/html; charset=utf-8")
+                    .build());
+            recordedRequest = takeRequest();
+        }
+
+        @Test
+        void shouldCheckHeaderValueStartingWith() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueStartingWith("Accept", "text/html"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeaderValueStartingWith() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueStartingWith("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value starting with: application/json");
+        }
+
+        @Test
+        void shouldCheckHeaderValueContaining() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueContaining("Accept", "charset"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeaderValueContaining() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueContaining("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value containing: application/json");
+        }
+
+        @Test
+        void shouldCheckHeader() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Accept", "text/html; charset=utf-8"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeader() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value: application/json");
         }
     }
 

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -36,7 +36,7 @@ import java.util.function.UnaryOperator;
 
 import javax.net.ssl.SSLHandshakeException;
 
-@DisplayName("RecordedRequestAssertions")
+@DisplayName("RecordedRequestAssertions (mockwebserver3)")
 class RecordedRequestAssertionsTest {
 
     private MockWebServer server;
@@ -504,6 +504,68 @@ class RecordedRequestAssertionsTest {
             assertThatThrownBy(() -> fn.apply(assertions))
                     .isNotNull()
                     .hasMessageContaining("Expected method to be " + method);
+        }
+    }
+
+    @Nested
+    class Headers {
+
+        private RecordedRequest recordedRequest;
+
+        @BeforeEach
+        void setUp() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.send(httpClient, HttpRequest.newBuilder()
+                    .GET()
+                    .uri(uri("/"))
+                    .header("Accept", "text/html; charset=utf-8")
+                    .build());
+            recordedRequest = takeRequest();
+        }
+
+        @Test
+        void shouldCheckHeaderValueStartingWith() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueStartingWith("Accept", "text/html"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeaderValueStartingWith() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueStartingWith("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value starting with: application/json");
+        }
+
+        @Test
+        void shouldCheckHeaderValueContaining() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueContaining("Accept", "charset"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeaderValueContaining() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueContaining("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value containing: application/json");
+        }
+
+        @Test
+        void shouldCheckHeader() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Accept", "text/html; charset=utf-8"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeader() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value: application/json");
         }
     }
 


### PR DESCRIPTION
Adds two new assertion methods to both the mockwebserver and mockwebserver3 versions of RecordedRequestAssertions to support partial header value matching.

hasHeaderValueStartingWith is useful for headers like Content-Type that include trailing metadata which callers want to ignore, e.g.:

    Content-Type: multipart/form-data; boundary=ExampleBoundaryString
    Content-Type: text/html; charset=utf-8

hasHeaderValueContaining is useful when certain values must be present but ordering or position is unpredictable, e.g.:

    Accept-Encoding: deflate, gzip;q=1.0, *;q=0.5

Also adds a dedicated Headers nested test class in both test files covering hasHeader, hasHeaderValueStartingWith, and hasHeaderValueContaining with both passing and failing scenarios. Disambiguates the DisplayName annotation on both test classes to make them easy to distinguish in IDE test runners.

Closes #652