### PR TITLE
test: disambiguate DisplayName annotations in okhttp3 test classes

### DIFF
--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerAssertionsTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.net.http.HttpClient;
 import java.time.Duration;
 
-@DisplayName("MockWebServerAssertions")
+@DisplayName("MockWebServerAssertions (mockwebserver)")
 class MockWebServerAssertionsTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.function.Consumer;
 
-@DisplayName("MockWebServerExtension")
+@DisplayName("MockWebServerExtension (mockwebserver)")
 class MockWebServerExtensionTest {
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServersTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.URI;
 
-@DisplayName("MockWebServers")
+@DisplayName("MockWebServers (mockwebserver)")
 class MockWebServersTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestsTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-@DisplayName("RecordedRequests")
+@DisplayName("RecordedRequests (mockwebserver)")
 class RecordedRequestsTest {
 
     @RegisterExtension

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerAssertionsTest.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.time.Duration;
 
-@DisplayName("MockWebServerAssertions")
+@DisplayName("MockWebServerAssertions (mockwebserver3)")
 class MockWebServerAssertionsTest {
 
     private MockWebServer server;

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.function.Consumer;
 
-@DisplayName("MockWebServerExtension")
+@DisplayName("MockWebServerExtension (mockwebserver3)")
 class MockWebServerExtensionTest {
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServersTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServersTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.net.URI;
 
-@DisplayName("MockWebServers")
+@DisplayName("MockWebServers (mockwebserver3)")
 class MockWebServersTest {
 
     private MockWebServer server;

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestsTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-@DisplayName("RecordedRequests")
+@DisplayName("RecordedRequests (mockwebserver3)")
 class RecordedRequestsTest {
 
     private MockWebServer server;


### PR DESCRIPTION
Both the mockwebserver and mockwebserver3 packages had identically named test classes,
making them difficult to distinguish in IDE test runners. Appended (mockwebserver) and
(mockwebserver3) suffixes to all DisplayName annotations across both packages.