### PR TITLE
feat: add resourceExtensionBuilderFor to DropwizardResourceTests

### DIFF
--- a/src/main/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTests.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTests.java
@@ -25,10 +25,26 @@ public class DropwizardResourceTests {
      * @see #resourceBuilderPreservingLogbackConfig()
      */
     public static ResourceExtension resourceExtensionFor(Object resource) {
+        return resourceExtensionBuilderFor(resource).build();
+    }
+
+    /**
+     * Create a {@link ResourceExtension.Builder} for the given Jakarta REST {@code resource}
+     * instance, preserving the existing Logback configuration by disabling the logging bootstrap.
+     * <p>
+     * This is useful when you need to add providers or other configuration beyond a single
+     * resource instance. If you don't need further customization, use
+     * {@link #resourceExtensionFor(Object)} instead.
+     *
+     * @param resource the Jakarta REST resource instance
+     * @return a new {@link ResourceExtension.Builder} instance with the resource already added
+     * @see #resourceExtensionFor(Object)
+     * @see #resourceBuilderPreservingLogbackConfig()
+     */
+    public static ResourceExtension.Builder resourceExtensionBuilderFor(Object resource) {
         checkArgumentNotNull(resource, "resource must not be null");
         return resourceBuilderPreservingLogbackConfig()
-                .addResource(resource)
-                .build();
+                .addResource(resource);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTestsTest.java
+++ b/src/test/java/org/kiwiproject/test/dropwizard/resource/DropwizardResourceTestsTest.java
@@ -106,6 +106,47 @@ class DropwizardResourceTestsTest {
     }
 
     @Nested
+    @ExtendWith(DropwizardExtensionsSupport.class)
+    class ResourceExtensionBuilderFor {
+
+        private static final ResourceExtension RESOURCES =
+                DropwizardResourceTests.resourceExtensionBuilderFor(new MyTestResource()).build();
+
+        @Test
+        void shouldCreateRegisteredResource() {
+            var response = RESOURCES.target("/test").request().get();
+
+            assertAll(
+                    () -> assertOkResponse(response),
+                    () -> assertThat(response.readEntity(String.class)).isEqualTo("hello"));
+        }
+
+        @Test
+        void shouldNotAllowNullResourceObject() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> DropwizardResourceTests.resourceExtensionBuilderFor(null))
+                    .withMessage("resource must not be null");
+        }
+
+        @ClearBoxTest("this directly accesses a private field and assumes a specific class structure")
+        void shouldSet_bootstrapLogging_toFalse() throws NoSuchFieldException, IllegalAccessException {
+            var builder = DropwizardResourceTests.resourceExtensionBuilderFor(new MyTestResource());
+            var field = builder.getClass().getSuperclass().getDeclaredField("bootstrapLogging");
+            assertThat(field)
+                    .describedAs("We did not find the 'bootstrapLogging' field. Dropwizard might have moved it.")
+                    .isNotNull();
+
+            field.setAccessible(true);
+
+            var value = field.get(builder);
+            var booleanValue = assertIsExactType(value, Boolean.class);
+            assertThat(booleanValue)
+                    .describedAs("bootstrapLogging should be false")
+                    .isFalse();
+        }
+    }
+
+    @Nested
     class ResourceBuilderPreservingLogbackConfig {
 
         private ResourceExtension.Builder builder;


### PR DESCRIPTION
Adds resourceExtensionBuilderFor(Object resource) which returns a
ResourceExtension.Builder with the resource pre-added and Logback
bootstrap disabled.

This sits between resourceExtensionFor (fully built, no customization)
and resourceBuilderPreservingLogbackConfig (blank builder), and is
useful when you need to add providers or other configuration before
building.

Also simplifies resourceExtensionFor to delegate to the new method.