### PR TITLE
feat: add missing error message and cause assertion methods to HealthCheckResultAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertions.java
+++ b/src/main/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertions.java
@@ -288,6 +288,72 @@ public class HealthCheckResultAssertions {
         return this;
     }
 
+    /**
+     * Asserts the health check result has an error whose message starts with the given prefix.
+     *
+     * @param messagePrefix the expected message prefix
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasErrorWithMessageStartingWith(String messagePrefix) {
+        assertResultHasError();
+
+        Assertions.assertThat(result.getError().getMessage())
+                .describedAs("Wrong error message prefix")
+                .startsWith(messagePrefix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error whose message ends with the given suffix.
+     *
+     * @param messageSuffix the expected message suffix
+     * @return this instance
+     */
+    public HealthCheckResultAssertions hasErrorWithMessageEndingWith(String messageSuffix) {
+        assertResultHasError();
+
+        Assertions.assertThat(result.getError().getMessage())
+                .describedAs("Wrong error message suffix")
+                .endsWith(messageSuffix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error whose cause is an instance of the given type.
+     *
+     * @param type the expected cause type
+     * @return this instance
+     * @implNote Uses {@link org.assertj.core.api.AbstractAssert#isInstanceOf(Class)}
+     */
+    public HealthCheckResultAssertions hasErrorWithCauseInstanceOf(Class<?> type) {
+        assertResultHasError();
+
+        Assertions.assertThat(result.getError().getCause())
+                .describedAs("Wrong error cause type")
+                .isInstanceOf(type);
+
+        return this;
+    }
+
+    /**
+     * Asserts the health check result has an error whose cause is EXACTLY the given type.
+     *
+     * @param type the expected exact cause type
+     * @return this instance
+     * @implNote Uses {@link org.assertj.core.api.AbstractAssert#isExactlyInstanceOf(Class)}
+     */
+    public HealthCheckResultAssertions hasErrorWithCauseExactlyInstanceOf(Class<?> type) {
+        assertResultHasError();
+
+        Assertions.assertThat(result.getError().getCause())
+                .describedAs("Wrong exact error cause type")
+                .isExactlyInstanceOf(type);
+
+        return this;
+    }
+
     private void assertResultHasError() {
         Assertions.assertThat(result.getError())
                 .describedAs("Expected to have an error")

--- a/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/assertj/dropwizard/metrics/HealthCheckResultAssertionsTest.java
@@ -404,6 +404,112 @@ class HealthCheckResultAssertionsTest {
                         .hasMessageContaining("Wrong error message fragment");
             }
         }
+
+        @Nested
+        class HasErrorWithMessageStartingWith {
+
+            @Test
+            void shouldPass_WhenErrorMessageStartsWith() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithMessageStartingWith("it's way"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotStartWith() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .hasErrorWithMessageStartingWith("way out"))
+                        .hasMessageContaining("Wrong error message prefix");
+            }
+        }
+
+        @Nested
+        class HasErrorWithMessageEndingWith {
+
+            @Test
+            void shouldPass_WhenErrorMessageEndsWith() {
+                assertThatCode(() ->
+                        assertThat(healthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithMessageEndingWith("out of date"))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorMessageDoesNotEndWith() {
+                assertThatThrownBy(() ->
+                        assertThat(healthCheck)
+                                .hasErrorWithMessageEndingWith("it's way"))
+                        .hasMessageContaining("Wrong error message suffix");
+            }
+        }
+
+        @Nested
+        class HasErrorWithCauseInstanceOf {
+
+            private HealthCheck causeHealthCheck;
+
+            @BeforeEach
+            void setUp() {
+                var cause = new IllegalStateException("underlying cause");
+                var error = new CertificateExpiredException("it's way out of date");
+                error.initCause(cause);
+                causeHealthCheck = MockHealthCheck.builder().healthy(false).error(error).build();
+            }
+
+            @Test
+            void shouldPass_WhenErrorCauseIsInstanceOfType() {
+                assertThatCode(() ->
+                        assertThat(causeHealthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithCauseInstanceOf(RuntimeException.class))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorCauseHasIncorrectType() {
+                assertThatThrownBy(() ->
+                        assertThat(causeHealthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithCauseInstanceOf(IllegalArgumentException.class))
+                        .hasMessageContaining("Wrong error cause type");
+            }
+        }
+
+        @Nested
+        class HasErrorWithCauseExactlyInstanceOf {
+
+            private HealthCheck causeHealthCheck;
+
+            @BeforeEach
+            void setUp() {
+                var cause = new IllegalStateException("underlying cause");
+                var error = new CertificateExpiredException("it's way out of date");
+                error.initCause(cause);
+                causeHealthCheck = MockHealthCheck.builder().healthy(false).error(error).build();
+            }
+
+            @Test
+            void shouldPass_WhenErrorCauseIsExactType() {
+                assertThatCode(() ->
+                        assertThat(causeHealthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithCauseExactlyInstanceOf(IllegalStateException.class))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldFail_WhenErrorCauseHasIncorrectType() {
+                assertThatThrownBy(() ->
+                        assertThat(causeHealthCheck)
+                                .isUnhealthy()
+                                .hasErrorWithCauseExactlyInstanceOf(RuntimeException.class))
+                        .hasMessageContaining("Wrong exact error cause type");
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
Adds hasErrorWithMessageStartingWith and hasErrorWithMessageEndingWith
to mirror the existing hasMessageStartingWith/hasMessageEndingWith
methods on the result message.

Adds hasErrorWithCauseInstanceOf and hasErrorWithCauseExactlyInstanceOf
to allow asserting on the cause of the error throwable.

Closes #657