### PR TITLE
Add BeforeAllCallback to ResetLogbackLoggingExtension

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -8,84 +8,102 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.kiwiproject.test.logback.LogbackTestHelper;
 
 /**
- * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} to reset
- * the Logback logging system after all tests have completed.
+ * A JUnit Jupiter {@link org.junit.jupiter.api.extension.Extension Extension} that resets
+ * the Logback logging system both before and after all tests in a class have run.
  * <p>
- * This is useful if something misbehaves, for example, Dropwizard's
+ * This is useful when something misbehaves with Logback. For example, Dropwizard's
  * <a href="https://www.dropwizard.io/en/stable/manual/testing.html#integration-testing">DropwizardAppExtension</a> and
  * <a href="https://www.dropwizard.io/en/stable/manual/testing.html#testing-client-implementations">DropwizardClientExtension</a>
- * extensions both stop and detach all appenders after all tests complete! Both of those extensions
- * reset Logback in
+ * reset Logback during bootstrap (silencing DEBUG and INFO logs during test execution) and again
+ * after all tests complete (stopping and detaching all appenders, which can leave later test
+ * classes with no log output at all). Both of those extensions reset Logback in
  * <a href="https://github.com/dropwizard/dropwizard/blob/297870e3b4b43ea9fb19417dd90ed78151cf6f5d/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L244">DropwizardTestSupport</a>.
  * Once this happens, there is either a minimal configuration that only logs at {@code INFO} and higher levels,
  * or worse, there is <em>no logging output</em> from later tests (in the case where it calls Logback's
- * {@link ch.qos.logback.classic.Logger#detachAndStopAllAppenders() Logger#detachAndStopAllAppenders()}.
+ * {@link ch.qos.logback.classic.Logger#detachAndStopAllAppenders() Logger#detachAndStopAllAppenders()}).
  * We consider this to be <em>bad</em>, since logging output is useful to track down causes if there are
  * other test failures. And, it's just not nice behavior to completely hijack logging!
+ *
+ * <h2>Recommended usage (as of kiwi-test 4.2.0)</h2>
  * <p>
- * You can use this extension in tests that are using misbehaving components to ensure that Logback
- * is reset after all tests complete, so that later tests have log output.
+ * Declare this extension as a {@code static final} field with
+ * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension}, while keeping
+ * {@code DropwizardExtensionsSupport} registered via {@code @ExtendWith} at the class level.
+ * Because {@code @ExtendWith} extensions are "outer" relative to {@code @RegisterExtension} field
+ * extensions, JUnit guarantees that {@code DropwizardExtensionsSupport}'s {@code beforeAll} always
+ * runs before this extension's {@code beforeAll}, and this extension's {@code afterAll} always runs
+ * before {@code DropwizardExtensionsSupport}'s {@code afterAll}. This means both the
+ * before-test and after-test Logback resets work correctly without any {@code @Order} annotations.
  * <p>
- * <strong>It is <em>very</em> important that this extension is registered <em>before</em> extensions
- * like {@code DropwizardExtensionsSupport} that also manipulate Logback. By registering it
- * before the other extensions, the {@code beforeAll} executes first, but the {@code afterAll}
- * executes <em>last</em>.</strong>
- * <p>
- * By executing this extension's {@code afterAll} last, we can guarantee to reset Logback logging.
- * Otherwise, the reset by this extension will be undone by the reset performed by
- * {@code DropwizardExtensionsSupport} (or similar).
- * <p>
- * For example, to use the default {@code logback-test.xml} as the logging configuration you
- * can use {@code @ExtendWith} on the test class:
+ * To use the default {@code logback-test.xml} configuration:
  * <pre>
- *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class)  // register first
  *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
  *   class SomeTest {
  *
- *       // test code that uses DropwizardClientExtension or DropwizardAppExtension
+ *      {@literal @}RegisterExtension
+ *       static final ResetLogbackLoggingExtension RESET_LOGBACK = new ResetLogbackLoggingExtension();
+ *
+ *       // test code that uses DropwizardAppExtension or DropwizardClientExtension
  *   }
  * </pre>
- * You can also use the {@link DropwizardExtensionsSupportWithLoggingReset} meta-annotation
- * which guarantees the correct order:
+ * To use a custom Logback configuration:
  * <pre>
- *   {@literal @}DropwizardExtensionsSupportWithLoggingReset
- *    class SomeTest {
+ *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
+ *   class SomeTest {
  *
- *        // test code that uses DropwizardClientExtension or DropwizardAppExtension
- *    }
- * </pre>
- * <p>
- * Alternatively, you can register the extension programmatically to use a custom
- * logging configuration. When doing this, you must register {@code DropwizardExtensionsSupport}
- * and similar extensions programmatically as well to ensure the correct order using
- * JUnit's {@link org.junit.jupiter.api.Order Order} annotation.
- * <pre>
- *   class AnotherTest {
- *
- *      {@literal @}Order(1)
  *      {@literal @}RegisterExtension
  *       static final ResetLogbackLoggingExtension RESET_LOGBACK = ResetLogbackLoggingExtension.builder()
  *               .logbackConfigFilePath("acme-special-logback.xml")
  *               .build();
  *
- *      {@literal @}Order(2)
- *      {@literal @}RegisterExtension
- *       static final DropwizardExtensionsSupport DW_SUPPORT = new DropwizardExtensionsSupport();
- *
- *       // test code that uses DropwizardClientExtension or DropwizardAppExtension
+ *       // test code that uses DropwizardAppExtension or DropwizardClientExtension
  *   }
  * </pre>
- * You can <em>not</em> register a static {@code ResetLogbackLoggingExtension} programmatically and
- * register {@code DropwizardExtensionsSupport} (or similar) using {@code @ExtendWith} at
- * the class level due to JUnit's ordering rules. See
- * <a href="https://docs.junit.org/current/user-guide/#extensions-registration-programmatic">Programmatic Extension Registration</a>
- * in the JUnit reference manual. To be sure of the extension order when using programmatic
- * registration, use explicit {@code @Order} annotations. It's also more clear and does not require
- * remembering the registration order or the differences between static and instance fields.
+ *
+ * <h2>Using {@code @ExtendWith} for both extensions</h2>
+ * <p>
+ * If you only need the {@code afterAll} reset (i.e. you do not need logging restored before tests
+ * run), you can still use {@code @ExtendWith} for both extensions. However, the ordering is
+ * critical: {@code ResetLogbackLoggingExtension} <em>must</em> be declared first so that its
+ * {@code afterAll} executes last (after Dropwizard has finished resetting Logback).
+ * The {@code beforeAll} in this case fires before Dropwizard's bootstrap reset, so it is a
+ * harmless no-op rather than a fix for in-test logging.
+ * <pre>
+ *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class)  // must be first
+ *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
+ *   class SomeTest {
+ *
+ *       // test code that uses DropwizardAppExtension or DropwizardClientExtension
+ *   }
+ * </pre>
+ * You can also use the {@link DropwizardExtensionsSupportWithLoggingReset} meta-annotation,
+ * which guarantees the correct order:
+ * <pre>
+ *  {@literal @}DropwizardExtensionsSupportWithLoggingReset
+ *   class SomeTest {
+ *
+ *       // test code that uses DropwizardAppExtension or DropwizardClientExtension
+ *   }
+ * </pre>
+ *
+ * <h2>Both extensions as {@code @RegisterExtension} fields</h2>
+ * <p>
+ * If {@code DropwizardExtensionsSupport} is also registered as a {@code @RegisterExtension} field
+ * rather than via {@code @ExtendWith}, there is no {@code @Order} combination that satisfies both
+ * the {@code beforeAll} and {@code afterAll} ordering requirements simultaneously. Migrate to the
+ * recommended pattern above ({@code @ExtendWith(DropwizardExtensionsSupport.class)} at the class
+ * level) to get the full benefit of both callbacks.
+ *
+ * <h2>Without Dropwizard</h2>
+ * <p>
+ * If you are not using Dropwizard, {@code @ExtendWith(ResetLogbackLoggingExtension.class)} is
+ * sufficient. The {@code beforeAll} fires harmlessly, and {@code afterAll} resets Logback after
+ * all tests complete.
  *
  * @see io.dropwizard.testing.junit5.DropwizardExtensionsSupport
  * @see DropwizardExtensionsSupportWithLoggingReset
@@ -95,7 +113,7 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
 @SuppressWarnings("LombokGetterMayBeUsed")
-public class ResetLogbackLoggingExtension implements AfterAllCallback {
+public class ResetLogbackLoggingExtension implements BeforeAllCallback, AfterAllCallback {
 
     /**
      * A custom location for the Logback configuration.
@@ -107,9 +125,16 @@ public class ResetLogbackLoggingExtension implements AfterAllCallback {
     private String logbackConfigFilePath;
 
     @Override
+    public void beforeAll(ExtensionContext context) {
+        getLogbackTestHelper().resetLogbackWithDefaultOrConfig(logbackConfigFilePath);
+        LOG.debug("Logback was reset (before all tests) using configuration: {} (if null, the Logback defaults are used)",
+                logbackConfigFilePath);
+    }
+
+    @Override
     public void afterAll(ExtensionContext context) {
         getLogbackTestHelper().resetLogbackWithDefaultOrConfig(logbackConfigFilePath);
-        LOG.debug("Logback was reset using configuration: {} (if null, the Logback defaults are used)",
+        LOG.debug("Logback was reset (after all tests) using configuration: {} (if null, the Logback defaults are used)",
                 logbackConfigFilePath);
     }
 

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
@@ -1,9 +1,19 @@
 package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.kiwiproject.test.logback.LogbackTestHelper;
 
 @DisplayName("ResetLogbackLoggingExtension")
 class ResetLogbackLoggingExtensionTest {
@@ -29,5 +39,79 @@ class ResetLogbackLoggingExtensionTest {
                 .build();
 
         assertThat(extension.getLogbackConfigFilePath()).isEqualTo(customLocation);
+    }
+
+    @Nested
+    class BeforeAll {
+
+        private LogbackTestHelper helper;
+        private ResetLogbackLoggingExtension extension;
+        private ExtensionContext extensionContext;
+
+        @BeforeEach
+        void setUp() {
+            helper = mock(LogbackTestHelper.class);
+            extensionContext = mock(ExtensionContext.class);
+        }
+
+        @Test
+        void shouldResetLogbackWithNullConfigByDefault() {
+            extension = spy(new ResetLogbackLoggingExtension());
+            when(extension.getLogbackTestHelper()).thenReturn(helper);
+
+            extension.beforeAll(extensionContext);
+
+            verify(helper).resetLogbackWithDefaultOrConfig(isNull());
+        }
+
+        @Test
+        void shouldResetLogbackWithCustomConfig() {
+            var customConfig = "acme-test-logback.xml";
+            extension = spy(ResetLogbackLoggingExtension.builder()
+                    .logbackConfigFilePath(customConfig)
+                    .build());
+            when(extension.getLogbackTestHelper()).thenReturn(helper);
+
+            extension.beforeAll(extensionContext);
+
+            verify(helper).resetLogbackWithDefaultOrConfig(eq(customConfig));
+        }
+    }
+
+    @Nested
+    class AfterAll {
+
+        private LogbackTestHelper helper;
+        private ResetLogbackLoggingExtension extension;
+        private ExtensionContext extensionContext;
+
+        @BeforeEach
+        void setUp() {
+            helper = mock(LogbackTestHelper.class);
+            extensionContext = mock(ExtensionContext.class);
+        }
+
+        @Test
+        void shouldResetLogbackWithNullConfigByDefault() {
+            extension = spy(new ResetLogbackLoggingExtension());
+            when(extension.getLogbackTestHelper()).thenReturn(helper);
+
+            extension.afterAll(extensionContext);
+
+            verify(helper).resetLogbackWithDefaultOrConfig(isNull());
+        }
+
+        @Test
+        void shouldResetLogbackWithCustomConfig() {
+            var customConfig = "acme-test-logback.xml";
+            extension = spy(ResetLogbackLoggingExtension.builder()
+                    .logbackConfigFilePath(customConfig)
+                    .build());
+            when(extension.getLogbackTestHelper()).thenReturn(helper);
+
+            extension.afterAll(extensionContext);
+
+            verify(helper).resetLogbackWithDefaultOrConfig(eq(customConfig));
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtensionTest.java
@@ -2,7 +2,6 @@ package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -74,7 +73,7 @@ class ResetLogbackLoggingExtensionTest {
 
             extension.beforeAll(extensionContext);
 
-            verify(helper).resetLogbackWithDefaultOrConfig(eq(customConfig));
+            verify(helper).resetLogbackWithDefaultOrConfig(customConfig);
         }
     }
 
@@ -111,7 +110,7 @@ class ResetLogbackLoggingExtensionTest {
 
             extension.afterAll(extensionContext);
 
-            verify(helper).resetLogbackWithDefaultOrConfig(eq(customConfig));
+            verify(helper).resetLogbackWithDefaultOrConfig(customConfig);
         }
     }
 }


### PR DESCRIPTION
Implements BeforeAllCallback so that Logback is restored both before and after all tests run. The beforeAll fires after DropwizardExtensionsSupport's bootstrap reset (when registered as a RegisterExtension field with ExtendWith(DropwizardExtensionsSupport.class) at the class level), ensuring DEBUG and INFO logs are available during test execution.

Rewrites the Javadoc to make the recommended RegisterExtension pattern the primary usage, covering all four registration scenarios and their ordering implications.

Expands the test to verify both beforeAll and afterAll invoke the LogbackTestHelper with the correct config.

Closes #659