### PR TITLE
docs: clarify DropwizardExtensionsSupportWithLoggingReset limitation

### DIFF
--- a/src/main/java/org/kiwiproject/test/junit/jupiter/DropwizardExtensionsSupportWithLoggingReset.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/DropwizardExtensionsSupportWithLoggingReset.java
@@ -9,28 +9,40 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A JUnit Jupiter meta-annotation that combines the functionality of {@link DropwizardExtensionsSupport}
- * and {@link ResetLogbackLoggingExtension}.
+ * A JUnit Jupiter meta-annotation that combines {@link DropwizardExtensionsSupport}
+ * and {@link ResetLogbackLoggingExtension} to restore Logback logging after all
+ * tests complete.
  * <p>
- * This annotation lets you use Dropwizard's testing support but ensures that the Logback logging system is
- * reset to the configuration in the default {@code logback-test.xml} file after all tests are completed.
+ * This annotation guarantees that {@link ResetLogbackLoggingExtension}'s
+ * {@code afterAll} executes <em>after</em> {@link DropwizardExtensionsSupport}'s
+ * {@code afterAll}, so Logback is restored to the default {@code logback-test.xml}
+ * configuration once the test class finishes. This prevents Dropwizard's cleanup
+ * from leaving later test classes with no log output.
  * <p>
- * Use this annotation on test classes to ensure the correct registration order.
- * The proper ordering ensures that {@link ResetLogbackLoggingExtension}'s {@code afterAll} logic
- * is executed last, guaranteeing that the Logback configuration is reset <em>after</em>
- * {@link DropwizardExtensionsSupport} does its own reset.
+ * <strong>Limitation:</strong> because both extensions are registered via
+ * {@code @ExtendWith} at the type level, {@link ResetLogbackLoggingExtension}'s
+ * {@code beforeAll} fires <em>before</em> {@link DropwizardExtensionsSupport}
+ * bootstraps Dropwizard. Dropwizard then resets Logback again during its own
+ * bootstrap, so logging is <em>not</em> restored during the test class itself -
+ * only after it completes.
  * <p>
- * You can use it like this:
+ * If you need logging restored both before and after tests (so that debug/info
+ * output is visible during the test run), or if you need a custom Logback
+ * configuration instead of the default {@code logback-test.xml}, use the
+ * recommended pattern instead: register {@link DropwizardExtensionsSupport}
+ * via {@code @ExtendWith} at the class level and
+ * {@link ResetLogbackLoggingExtension} as a {@code @RegisterExtension static final}
+ * field. See {@link ResetLogbackLoggingExtension} for the recommended pattern
+ * and examples.
+ * <p>
+ * For the afterAll-only use case, this annotation is enough:
  * <pre>
  * {@literal @}DropwizardExtensionsSupportWithLoggingReset
- *  class SomeTestUsingDropwizardExtensions {
+ *  class SomeTest {
  *
  *      // test code that uses DropwizardClientExtension or DropwizardAppExtension
  *  }
  * </pre>
- * If you need to use a custom Logback configuration instead of the default {@code logback-test.xml},
- * then you'll need to register {@link ResetLogbackLoggingExtension} and {@link DropwizardExtensionsSupport}
- * programmatically and ensure the correct order using
  *
  * @see ResetLogbackLoggingExtension
  * @see DropwizardExtensionsSupport

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -21,7 +21,7 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
  * <a href="https://www.dropwizard.io/en/stable/manual/testing.html#testing-client-implementations">DropwizardClientExtension</a>
  * reset Logback during bootstrap (silencing DEBUG and INFO logs during test execution) and again
  * after all tests complete (stopping and detaching all appenders, which can leave later test
- * classes with no log output at all). Both of those extensions reset Logback in
+ * classes with no log output). Both of those extensions reset Logback in
  * <a href="https://github.com/dropwizard/dropwizard/blob/297870e3b4b43ea9fb19417dd90ed78151cf6f5d/dropwizard-testing/src/main/java/io/dropwizard/testing/DropwizardTestSupport.java#L244">DropwizardTestSupport</a>.
  * Once this happens, there is either a minimal configuration that only logs at {@code INFO} and higher levels,
  * or worse, there is <em>no logging output</em> from later tests (in the case where it calls Logback's
@@ -67,14 +67,14 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
  *
  * <h2>Using {@code @ExtendWith} for both extensions</h2>
  * <p>
- * If you only need the {@code afterAll} reset (i.e. you do not need logging restored before tests
+ * If you only need the {@code afterAll} reset (i.e., you do not need logging restored before tests
  * run), you can still use {@code @ExtendWith} for both extensions. However, the ordering is
  * critical: {@code ResetLogbackLoggingExtension} <em>must</em> be declared first so that its
  * {@code afterAll} executes last (after Dropwizard has finished resetting Logback).
  * The {@code beforeAll} in this case fires before Dropwizard's bootstrap reset, so it is a
  * harmless no-op rather than a fix for in-test logging.
  * <pre>
- *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class)  // must be first
+ *  {@literal @}ExtendWith(ResetLogbackLoggingExtension.class) // must be first
  *  {@literal @}ExtendWith(DropwizardExtensionsSupport.class)
  *   class SomeTest {
  *
@@ -82,7 +82,9 @@ import org.kiwiproject.test.logback.LogbackTestHelper;
  *   }
  * </pre>
  * You can also use the {@link DropwizardExtensionsSupportWithLoggingReset} meta-annotation,
- * which guarantees the correct order:
+ * which guarantees the correct order. Note that it only provides the {@code afterAll}
+ * reset - logging is not restored during the test run itself (see that annotation's
+ * Javadoc for details):
  * <pre>
  *  {@literal @}DropwizardExtensionsSupportWithLoggingReset
  *   class SomeTest {


### PR DESCRIPTION
The meta-annotation only provides the afterAll Logback reset - because
both extensions are registered via ExtendWith at the type level,
ResetLogbackLoggingExtension's beforeAll fires before Dropwizard
bootstraps, so Dropwizard's own bootstrap resets Logback again and
logging is not restored during the test run.

Updated the Javadoc for DropwizardExtensionsSupportWithLoggingReset to
explain this limitation clearly, fix a cut-off sentence, and point
users to the RegisterExtension pattern when they need logging restored
both before and after tests, or when they need a custom Logback
configuration.

Also updated ResetLogbackLoggingExtension's Javadoc to note that the
DropwizardExtensionsSupportWithLoggingReset example in the ExtendWith
section only provides the afterAll reset.