### PR TITLE
feat: add @NonNull annotations to JUnit Jupiter extension method overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,12 @@
         <sonar.projectKey>kiwiproject_kiwi-test</sonar.projectKey>
         <sonar.organization>kiwiproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.cpd.exclusions>**/okhttp3/mockwebserver3/**</sonar.cpd.exclusions>
+        <sonar.cpd.exclusions>
+            **/okhttp3/mockwebserver3/**,
+            **/Jdbi3DaoExtension.java,
+            **/Jdbi3Extension.java,
+            **/Jdbi3MultiDaoExtension.java
+        </sonar.cpd.exclusions>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
+++ b/src/main/java/org/kiwiproject/test/dropwizard/app/PostgresAppTestExtension.java
@@ -10,6 +10,7 @@ import io.zonky.test.db.postgres.junit5.EmbeddedPostgresExtension;
 import io.zonky.test.db.postgres.junit5.PreparedDbExtension;
 import lombok.Getter;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -186,13 +187,13 @@ public class PostgresAppTestExtension<T extends Configuration> implements Before
     }
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+    public void beforeAll(@NonNull ExtensionContext extensionContext) throws Exception {
         postgres.beforeAll(extensionContext);
         app.before();
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) {
+    public void afterAll(@NonNull ExtensionContext extensionContext) {
         app.after();
         postgres.afterAll(extensionContext);
     }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/AsyncModeDisablingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/AsyncModeDisablingExtension.java
@@ -4,6 +4,7 @@ import static org.kiwiproject.concurrent.Async.Mode.DISABLED;
 import static org.kiwiproject.concurrent.Async.Mode.ENABLED;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -39,13 +40,13 @@ import org.kiwiproject.concurrent.Async;
 public class AsyncModeDisablingExtension implements BeforeEachCallback, AfterEachCallback {
 
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         LOG.trace("Setting async mode to DISABLED");
         Async.setUnitTestAsyncMode(DISABLED);
     }
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         LOG.trace("Setting async mode to ENABLED");
         Async.setUnitTestAsyncMode(ENABLED);
     }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2FileBasedDatabaseExtension.java
@@ -8,6 +8,7 @@ import static org.kiwiproject.test.junit.jupiter.JupiterHelpers.testClassNameOrN
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -86,7 +87,7 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
      * @param context extension context
      */
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(@NonNull ExtensionContext context) {
         if (nonNull(database)) {
             LOG.trace("A database already exists (we are probably inside a @Nested test class) so not doing anything");
             return;
@@ -107,7 +108,7 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
      * @throws Exception if the database directory could not be deleted
      */
     @Override
-    public void afterAll(ExtensionContext context) throws Exception {
+    public void afterAll(@NonNull ExtensionContext context) throws Exception {
         if (isTestClassNested(context)) {
             LOG.trace("We're in nested class {}, so NOT deleting the database", testClassNameOrNull(context));
         } else {
@@ -140,7 +141,8 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
      * @return true if the {@code parameterContext} is annotated with {@link H2Database}
      */
     @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    public boolean supportsParameter(ParameterContext parameterContext,
+            @NonNull ExtensionContext extensionContext) {
         return parameterContext.isAnnotated(H2Database.class);
     }
 
@@ -152,7 +154,8 @@ public class H2FileBasedDatabaseExtension implements BeforeAllCallback, AfterAll
      * @return the resolved {@link H2FileBasedDatabase}
      */
     @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    public Object resolveParameter(@NonNull ParameterContext parameterContext,
+            @NonNull ExtensionContext extensionContext) {
         var namespace = createNamespace();
 
         return getDatabase(extensionContext, namespace);

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/H2LiquibaseExtension.java
@@ -11,6 +11,7 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.CommandExecutionException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -109,7 +110,7 @@ public class H2LiquibaseExtension implements BeforeAllCallback, AfterAllCallback
      * @throws Exception if any error occurs initializing the H2 database, executing migrations, or connecting
      */
     @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
+    public void beforeAll(@NonNull ExtensionContext context) throws Exception {
         if (nonNull(database)) {
             LOG.trace("Database exists (we are probably inside a @Nested test class) so not doing anything");
             return;
@@ -141,7 +142,7 @@ public class H2LiquibaseExtension implements BeforeAllCallback, AfterAllCallback
      * @throws Exception if any error occurs deleting the test database directory
      */
     @Override
-    public void afterAll(ExtensionContext context) throws Exception {
+    public void afterAll(@NonNull ExtensionContext context) throws Exception {
         LOG.trace("Invoke H2FileBasedDatabaseExtension.afterAll() to shut down H2 database (if not in nested class)");
         h2Extension.afterAll(context);
     }
@@ -154,7 +155,8 @@ public class H2LiquibaseExtension implements BeforeAllCallback, AfterAllCallback
      * @return true if the {@code parameterContext} is annotated with {@link H2Database}
      */
     @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    public boolean supportsParameter(@NonNull ParameterContext parameterContext,
+            @NonNull ExtensionContext extensionContext) {
         return h2Extension.supportsParameter(parameterContext, extensionContext);
     }
 
@@ -166,7 +168,8 @@ public class H2LiquibaseExtension implements BeforeAllCallback, AfterAllCallback
      * @return the resolved {@link H2FileBasedDatabase}
      */
     @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    public Object resolveParameter(@NonNull ParameterContext parameterContext,
+            @NonNull ExtensionContext extensionContext) {
         return h2Extension.resolveParameter(parameterContext, extensionContext);
     }
 

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3DaoExtension.java
@@ -14,6 +14,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -130,7 +131,7 @@ public class Jdbi3DaoExtension<T> implements BeforeEachCallback, AfterEachCallba
      * @see Handle#begin()
      */
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         LOG.trace("Setting up for JDBI DAO test");
 
         LOG.trace("Opening handle");
@@ -158,7 +159,7 @@ public class Jdbi3DaoExtension<T> implements BeforeEachCallback, AfterEachCallba
      * @see Handle#close()
      */
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         Jdbi3Helpers.rollbackAndClose(handle, LOG);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Extension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3Extension.java
@@ -13,6 +13,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -107,7 +108,7 @@ public class Jdbi3Extension implements BeforeEachCallback, AfterEachCallback {
      * @see Handle#begin()
      */
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         LOG.trace("Setting up for JDBI test");
 
         LOG.trace("Opening handle");
@@ -132,7 +133,7 @@ public class Jdbi3Extension implements BeforeEachCallback, AfterEachCallback {
      * @see Handle#close()
      */
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         Jdbi3Helpers.rollbackAndClose(handle, LOG);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3MultiDaoExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/Jdbi3MultiDaoExtension.java
@@ -15,6 +15,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.argument.ArgumentFactory;
 import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -132,7 +133,7 @@ public class Jdbi3MultiDaoExtension implements BeforeEachCallback, AfterEachCall
      * @see Handle#begin()
      */
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         LOG.trace("Setting up for JDBI multi-DAO test");
 
         LOG.trace("Opening handle");
@@ -170,7 +171,7 @@ public class Jdbi3MultiDaoExtension implements BeforeEachCallback, AfterEachCall
      * @see Handle#close()
      */
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         Jdbi3Helpers.rollbackAndClose(handle, LOG);
     }
 

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoDbExtension.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -264,7 +265,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         if (dropTime == DropTime.BEFORE_EACH) {
             dropDatabase();
             LOG.debug("@BeforeEach: Database {} was dropped", databaseName);
@@ -272,7 +273,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
     }
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         if (dropTime == DropTime.AFTER_ALL) {
             clearCollections(databaseName, cleanupOption);
             LOG.debug("@AfterEach: Collections cleaned with option {} in database {} @AfterEach", cleanupOption, databaseName);
@@ -283,7 +284,7 @@ public class MongoDbExtension implements BeforeEachCallback, AfterEachCallback, 
     }
 
     @Override
-    public void afterAll(ExtensionContext extensionContext) {
+    public void afterAll(@NonNull ExtensionContext extensionContext) {
         if (dropTime == DropTime.AFTER_ALL) {
             dropDatabase();
             LOG.debug("@AfterAll: Database {} was dropped", databaseName);

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/MongoServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/MongoServerExtension.java
@@ -11,6 +11,7 @@ import de.bwaldvogel.mongo.MongoServer;
 import de.bwaldvogel.mongo.ServerVersion;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -176,7 +177,7 @@ public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(@NonNull ExtensionContext context) {
         mongoServer = startInMemoryMongoServer(serverVersion);
         connectionString = MongoServerTests.getConnectionString(mongoServer);
         testDatabaseName = generateTestDatabaseName();
@@ -192,7 +193,7 @@ public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback
     }
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         if (dropTime == DropTime.AFTER_EACH) {
             dropAndRecreateTestDatabase();
             LOG.trace("@AfterEach: Database {} was dropped and re-created", testDatabaseName);
@@ -205,7 +206,7 @@ public class MongoServerExtension implements BeforeAllCallback, AfterAllCallback
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterAll(@NonNull ExtensionContext context) {
         LOG.trace("@AfterAll: Closing Mongo client and shutting in-memory MongoServer down");
         mongoClient.close();
         mongoServer.shutdownNow();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/PostgresLiquibaseTestExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/PostgresLiquibaseTestExtension.java
@@ -8,6 +8,7 @@ import io.zonky.test.db.postgres.junit5.EmbeddedPostgresExtension;
 import io.zonky.test.db.postgres.junit5.PreparedDbExtension;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -89,7 +90,7 @@ public class PostgresLiquibaseTestExtension implements BeforeAllCallback, AfterA
      * @throws Exception if any error occurs while initializing the embedded Postgres or connecting to it
      */
     @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
+    public void beforeAll(@NonNull ExtensionContext context) throws Exception {
         LOG.trace("Invoke PreparedDbExtension.beforeAll() to initialize the embedded Postgres");
         postgres.beforeAll(context);
 
@@ -106,7 +107,7 @@ public class PostgresLiquibaseTestExtension implements BeforeAllCallback, AfterA
      * @param context the extension context
      */
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterAll(@NonNull ExtensionContext context) {
         if (nonNull(testDataSource)) {
             LOG.trace("Closing test DataSource");
             testDataSource.close();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtension.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.test.junit.jupiter;
 
 import jakarta.validation.Validator;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.kiwiproject.validation.KiwiValidations;
@@ -15,7 +16,7 @@ import org.kiwiproject.validation.KiwiValidations;
 public class ResetKiwiValidationExtension implements AfterAllCallback {
 
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterAll(@NonNull ExtensionContext context) {
         var freshValidator = KiwiValidations.newValidator();
         KiwiValidations.setValidator(freshValidator);
     }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/ResetLogbackLoggingExtension.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -127,14 +128,14 @@ public class ResetLogbackLoggingExtension implements BeforeAllCallback, AfterAll
     private String logbackConfigFilePath;
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(@NonNull ExtensionContext context) {
         getLogbackTestHelper().resetLogbackWithDefaultOrConfig(logbackConfigFilePath);
         LOG.debug("Logback was reset (before all tests) using configuration: {} (if null, the Logback defaults are used)",
                 logbackConfigFilePath);
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterAll(@NonNull ExtensionContext context) {
         getLogbackTestHelper().resetLogbackWithDefaultOrConfig(logbackConfigFilePath);
         LOG.debug("Logback was reset (after all tests) using configuration: {} (if null, the Logback defaults are used)",
                 logbackConfigFilePath);

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/AsciiOnlyBlankStringArgumentsProvider.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static java.util.Collections.unmodifiableList;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -69,7 +70,8 @@ public class AsciiOnlyBlankStringArgumentsProvider implements ArgumentsProvider 
      * exhausted. So don't do that.
      */
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         return ASCII_ONLY_BLANK_STRINGS.stream().map(Arguments::of);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/BlankStringArgumentsProvider.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static java.util.Collections.unmodifiableList;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -99,7 +100,8 @@ public class BlankStringArgumentsProvider implements ArgumentsProvider {
      * exhausted. So don't do that.
      */
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         return BLANK_STRINGS.stream().map(Arguments::of);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/MinimalBlankStringArgumentsProvider.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static java.util.Collections.unmodifiableList;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -40,7 +41,8 @@ public class MinimalBlankStringArgumentsProvider implements ArgumentsProvider {
     );
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         return BLANK_STRINGS.stream().map(Arguments::of);
     }
 }

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProvider.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -27,7 +28,8 @@ class RandomDoubleArgumentsProvider implements ArgumentsProvider, AnnotationCons
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         checkArgument(randomDoubleSource.min() <= randomDoubleSource.max(), "min must be equal or less than max");
 
         var random = ThreadLocalRandom.current();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProvider.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -36,7 +37,8 @@ class RandomIntArgumentsProvider implements ArgumentsProvider, AnnotationConsume
      * {@link ThreadLocalRandom#nextInt(int, int)}.
      */
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         checkArgument(randomIntSource.min() <= randomIntSource.max(), "min must be equal or less than max");
 
         var random = ThreadLocalRandom.current();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProvider.java
@@ -2,6 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -27,7 +28,8 @@ class RandomLongArgumentsProvider implements ArgumentsProvider, AnnotationConsum
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         checkArgument(randomLongSource.min() <= randomLongSource.max(), "min must be equal or less than max");
 
         var random = ThreadLocalRandom.current();

--- a/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProvider.java
+++ b/src/main/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProvider.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -31,7 +32,8 @@ public class RandomStringArgumentsProvider implements ArgumentsProvider, Annotat
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    public @NonNull Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters,
+            @NonNull ExtensionContext context) {
         checkArgument(randomStringSource.minLength() <= randomStringSource.maxLength(),
                 "minLength must be equal or less than maxLength");
 

--- a/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
+++ b/src/main/java/org/kiwiproject/test/logback/InMemoryAppenderExtension.java
@@ -9,6 +9,7 @@ import ch.qos.logback.core.Appender;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -151,7 +152,7 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
      * @param context the current extension context; never {@code null}
      */
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         var logbackLogger = (Logger) LoggerFactory.getLogger(loggerClass);
         var rawAppender = getAppender(logbackLogger);
 
@@ -199,7 +200,7 @@ public class InMemoryAppenderExtension implements BeforeEachCallback, AfterEachC
      * @see InMemoryAppender#clearEvents()
      */
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         appender.clearEvents();
     }
 }

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtension.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import okhttp3.mockwebserver.MockWebServer;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -92,7 +93,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
      * @throws IOException if an error occurs starting the {@link MockWebServer}
      */
     @Override
-    public void beforeEach(ExtensionContext context) throws IOException {
+    public void beforeEach(@NonNull ExtensionContext context) throws IOException {
         serverCustomizer.accept(server);
         server.start();
         uri = MockWebServers.uri(server);
@@ -104,7 +105,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
      * @param context the current extension context; never {@code null}
      */
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         KiwiIO.closeQuietly(server);
     }
 

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtension.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtension.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import mockwebserver3.MockWebServer;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -95,7 +96,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
      * @throws IOException if an error occurs starting the {@link MockWebServer}
      */
     @Override
-    public void beforeEach(ExtensionContext context) throws IOException {
+    public void beforeEach(@NonNull ExtensionContext context) throws IOException {
         serverCustomizer.accept(server);
         server.start();
         uri = MockWebServers.uri(server);
@@ -107,7 +108,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
      * @param context the current extension context; never {@code null}
      */
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         server.close();
     }
 

--- a/src/test/java/org/kiwiproject/test/curator/CuratorTestingServerExtensionImmediateStartTest.java
+++ b/src/test/java/org/kiwiproject/test/curator/CuratorTestingServerExtensionImmediateStartTest.java
@@ -9,6 +9,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.RetryOneTime;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -52,7 +53,7 @@ class CuratorTestingServerExtensionImmediateStartTest {
          * Creates a new Curator client and attempts to connect to the testing server.
          */
         @Override
-        public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        public void beforeAll(@NonNull ExtensionContext extensionContext) throws Exception {
             var sessionTimeoutMs = 2_000;
             var connectionTimeoutMs = 1_000;
             var sleepMsBetweenRetry = 500;

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/H2DatabaseTestExtension.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/H2DatabaseTestExtension.java
@@ -3,6 +3,7 @@ package org.kiwiproject.test.junit.jupiter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -21,12 +22,12 @@ public class H2DatabaseTestExtension implements BeforeEachCallback, AfterEachCal
     private final H2FileBasedDatabase database;
 
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NonNull ExtensionContext context) {
         LOG.debug("Database in beforeEach: {}", database);
     }
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterEach(@NonNull ExtensionContext context) {
         LOG.debug("Database in afterEach: {}", database);
     }
 }


### PR DESCRIPTION
Add JSpecify NonNull annotations to method parameters and return types
that override NullMarked interface methods in JUnit Jupiter extensions
and argument providers. Also wrap long method signatures that resulted
from the added annotations onto separate lines for readability.

The JUnit Jupiter interfaces are under NullMarked, so overriding
methods without nullability annotations in scope caused IntelliJ to
report "Not annotated parameter overrides NullMarked parameter"
warnings. Adding NonNull resolves the mismatch without requiring
package-level NullMarked declarations.