### PR TITLE
test: replace null with mocks for ExtensionContext and ParameterDeclarations

### DIFF
--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtensionTest.java
@@ -20,7 +20,8 @@ class ResetKiwiValidationExtensionTest {
 
         @BeforeEach
         void setUp() {
-            extensionContext = mock(ExtensionContext.class);
+            extensionContext = mock(ExtensionContext.class,
+                    invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
         }
 
         @RepeatedTest(10)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtensionTest.java
@@ -1,10 +1,13 @@
 package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.kiwiproject.validation.KiwiValidations;
 
 @DisplayName("ResetKiwiValidationExtension")
@@ -13,11 +16,18 @@ class ResetKiwiValidationExtensionTest {
     @Nested
     class AfterAll {
 
+        private ExtensionContext extensionContext;
+
+        @BeforeEach
+        void setUp() {
+            extensionContext = mock(ExtensionContext.class);
+        }
+
         @RepeatedTest(10)
         void shouldSetNewValidatorInstance() {
             var originalValidator = KiwiValidations.getValidator();
 
-            new ResetKiwiValidationExtension().afterAll(null);
+            new ResetKiwiValidationExtension().afterAll(extensionContext);
 
             assertThat(KiwiValidations.getValidator()).isNotSameAs(originalValidator);
         }

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
@@ -2,14 +2,18 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -19,6 +23,15 @@ import java.util.concurrent.ThreadLocalRandom;
 @Slf4j
 class RandomDoubleArgumentsProviderTest {
 
+    private ExtensionContext extensionContext;
+    private ParameterDeclarations parameterDeclarations;
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = mock(ExtensionContext.class);
+        parameterDeclarations = mock(ParameterDeclarations.class);
+    }
+
     @Test
     void shouldThrowIllegalArgumentException_WhenMaxLessThanMin() {
         var randomDoubleSource = newRandomDoubleSource(10.0, 9.9, 25);
@@ -26,7 +39,7 @@ class RandomDoubleArgumentsProviderTest {
         provider.accept(randomDoubleSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("min must be equal or less than max");
     }
 
@@ -40,7 +53,7 @@ class RandomDoubleArgumentsProviderTest {
         var provider = new RandomDoubleArgumentsProvider();
         provider.accept(randomDoubleSource);
 
-        var arguments = provider.provideArguments(null, null)
+        var arguments = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToDouble(value -> (double) value)
@@ -63,7 +76,7 @@ class RandomDoubleArgumentsProviderTest {
         var provider = new RandomDoubleArgumentsProvider();
         provider.accept(randomDoubleSource);
 
-        var arguments = provider.provideArguments(null, null)
+        var arguments = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToDouble(value -> (double) value)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
@@ -28,8 +28,10 @@ class RandomDoubleArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class);
-        parameterDeclarations = mock(ParameterDeclarations.class);
+        extensionContext = mock(ExtensionContext.class,
+                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+        parameterDeclarations = mock(ParameterDeclarations.class,
+                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
@@ -24,8 +24,10 @@ class RandomIntArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class);
-        parameterDeclarations = mock(ParameterDeclarations.class);
+        extensionContext = mock(ExtensionContext.class,
+                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+        parameterDeclarations = mock(ParameterDeclarations.class,
+                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
@@ -3,17 +3,30 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 
 @DisplayName("RandomIntArgumentsProvider")
 class RandomIntArgumentsProviderTest {
+
+    private ExtensionContext extensionContext;
+    private ParameterDeclarations parameterDeclarations;
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = mock(ExtensionContext.class);
+        parameterDeclarations = mock(ParameterDeclarations.class);
+    }
 
     @Test
     void shouldThrowIllegalArgumentException_WhenMaxLessThanMin() {
@@ -22,7 +35,7 @@ class RandomIntArgumentsProviderTest {
         provider.accept(randomIntSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("min must be equal or less than max");
     }
 
@@ -33,7 +46,7 @@ class RandomIntArgumentsProviderTest {
         var provider = new RandomIntArgumentsProvider();
         provider.accept(randomIntSource);
 
-        var arguments = provider.provideArguments(null, null)
+        var arguments = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToInt(value -> (int) value)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
@@ -2,17 +2,30 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 
 @DisplayName("RandomLongArgumentsProvider")
 class RandomLongArgumentsProviderTest {
+
+    private ExtensionContext extensionContext;
+    private ParameterDeclarations parameterDeclarations;
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = mock(ExtensionContext.class);
+        parameterDeclarations = mock(ParameterDeclarations.class);
+    }
 
     @Test
     void shouldThrowIllegalArgumentException_WhenMaxLessThanMin() {
@@ -21,7 +34,7 @@ class RandomLongArgumentsProviderTest {
         provider.accept(randomLongSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("min must be equal or less than max");
     }
 
@@ -32,7 +45,7 @@ class RandomLongArgumentsProviderTest {
         var provider = new RandomLongArgumentsProvider();
         provider.accept(randomLongSource);
 
-        var arguments = provider.provideArguments(null, null)
+        var arguments = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .mapToLong(value -> (long) value)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
@@ -23,8 +23,10 @@ class RandomLongArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class);
-        parameterDeclarations = mock(ParameterDeclarations.class);
+        extensionContext = mock(ExtensionContext.class,
+                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+        parameterDeclarations = mock(ParameterDeclarations.class,
+                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
@@ -9,18 +9,22 @@ import static org.apache.commons.lang3.CharUtils.isAsciiPrintable;
 import static org.apache.commons.lang3.StringUtils.containsOnly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.junitpioneer.jupiter.params.IntRangeSource;
 import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.CountStrategy;
 import org.kiwiproject.test.junit.jupiter.params.provider.RandomStringSource.RandomSecurity;
@@ -36,6 +40,15 @@ import java.util.stream.IntStream;
 @DisplayName("RandomStringArgumentsProvider")
 @Slf4j
 class RandomStringArgumentsProviderTest {
+
+    private ExtensionContext extensionContext;
+    private ParameterDeclarations parameterDeclarations;
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = mock(ExtensionContext.class);
+        parameterDeclarations = mock(ParameterDeclarations.class);
+    }
 
     @ParameterizedTest
     @RandomStringSource(randomSecurity = RandomSecurity.SECURE)
@@ -96,7 +109,7 @@ class RandomStringArgumentsProviderTest {
 
         var provider = createAndInitProvider(randomStringSource);
 
-        var values = provider.provideArguments(null, null)
+        var values = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .map(String.class::cast)
@@ -144,7 +157,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("count must be greater than zero");
     }
 
@@ -169,7 +182,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("minLength must be equal or less than maxLength");
     }
 
@@ -194,7 +207,7 @@ class RandomStringArgumentsProviderTest {
 
         var provider = createAndInitProvider(randomStringSource);
 
-        var arguments = provider.provideArguments(null, null)
+        var arguments = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .map(String.class::cast)
@@ -221,7 +234,7 @@ class RandomStringArgumentsProviderTest {
 
         var provider = createAndInitProvider(randomStringSource);
 
-        var arguments = provider.provideArguments(null, null)
+        var arguments = provider.provideArguments(parameterDeclarations, extensionContext)
                 .map(Arguments::get)
                 .flatMap(Arrays::stream)
                 .map(String.class::cast)
@@ -249,7 +262,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("minCount must be greater than zero, and maxCount must be greater or equal to minCount");
     }
 
@@ -312,7 +325,7 @@ class RandomStringArgumentsProviderTest {
         // we need to force the stream to terminate for this test
         //noinspection ResultOfMethodCallIgnored
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null).toList())
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext).toList())
                 .withMessage("chars must have at least one character");
     }
 
@@ -346,7 +359,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("endChar must be higher than beginChar");
     }
 
@@ -382,7 +395,7 @@ class RandomStringArgumentsProviderTest {
         var provider = createAndInitProvider(randomStringSource);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> provider.provideArguments(null, null))
+                .isThrownBy(() -> provider.provideArguments(parameterDeclarations, extensionContext))
                 .withMessage("beginChars and endChars must have the same length");
     }
 

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
@@ -46,8 +46,10 @@ class RandomStringArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class);
-        parameterDeclarations = mock(ParameterDeclarations.class);
+        extensionContext = mock(ExtensionContext.class,
+                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+        parameterDeclarations = mock(ParameterDeclarations.class,
+                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
     }
 
     @ParameterizedTest

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
@@ -35,7 +35,8 @@ class MockWebServerExtensionTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class);
+        extensionContext = mock(ExtensionContext.class,
+                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
@@ -14,9 +14,11 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Strings;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.junit.jupiter.params.provider.MinimalBlankStringSource;
@@ -28,6 +30,13 @@ import java.util.function.Consumer;
 
 @DisplayName("MockWebServerExtension (mockwebserver)")
 class MockWebServerExtensionTest {
+
+    private ExtensionContext extensionContext;
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = mock(ExtensionContext.class);
+    }
 
     @Nested
     class NoArgsConstructor {
@@ -119,7 +128,7 @@ class MockWebServerExtensionTest {
             when(server.url(anyString())).thenReturn(mock(HttpUrl.class));
 
             var extension = MockWebServerExtension.builder().server(server).build();
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             verify(server).start();
         }
@@ -135,7 +144,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .serverCustomizer(customizer)
                     .build();
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             verify(customizer, only()).accept(server);
         }
@@ -149,7 +158,7 @@ class MockWebServerExtensionTest {
             when(server.url(anyString())).thenReturn(httpUrl);
 
             var extension = MockWebServerExtension.builder().server(server).build();
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             assertThat(extension.uri()).isSameAs(uri);
         }
@@ -163,7 +172,7 @@ class MockWebServerExtensionTest {
             var server = mock(MockWebServer.class);
 
             var extension = MockWebServerExtension.builder().server(server).build();
-            extension.afterEach(null);
+            extension.afterEach(extensionContext);
 
             verify(server, only()).close();
         }
@@ -216,7 +225,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .build();
 
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> extension.uri(null))
@@ -231,7 +240,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .build();
 
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             // MinimalBlankStringSource gives us a null, which we need to ignore,
             // so convert it to an empty string.
@@ -255,7 +264,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .build();
 
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             // handle the special case of an empty string; the resulting
             // path should end with a slash

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
@@ -34,7 +34,8 @@ class MockWebServerExtensionTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class);
+        extensionContext = mock(ExtensionContext.class,
+                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
@@ -13,9 +13,11 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Strings;
 import mockwebserver3.MockWebServer;
 import okhttp3.HttpUrl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.test.junit.jupiter.params.provider.MinimalBlankStringSource;
@@ -27,6 +29,13 @@ import java.util.function.Consumer;
 
 @DisplayName("MockWebServerExtension (mockwebserver3)")
 class MockWebServerExtensionTest {
+
+    private ExtensionContext extensionContext;
+
+    @BeforeEach
+    void setUp() {
+        extensionContext = mock(ExtensionContext.class);
+    }
 
     @Nested
     class NoArgsConstructor {
@@ -118,7 +127,7 @@ class MockWebServerExtensionTest {
             when(server.url(anyString())).thenReturn(mock(HttpUrl.class));
 
             var extension = MockWebServerExtension.builder().server(server).build();
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             verify(server).start();
         }
@@ -134,7 +143,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .serverCustomizer(customizer)
                     .build();
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             verify(customizer, only()).accept(server);
         }
@@ -148,7 +157,7 @@ class MockWebServerExtensionTest {
             when(server.url(anyString())).thenReturn(httpUrl);
 
             var extension = MockWebServerExtension.builder().server(server).build();
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             assertThat(extension.uri()).isSameAs(uri);
         }
@@ -162,7 +171,7 @@ class MockWebServerExtensionTest {
             var server = mock(MockWebServer.class);
 
             var extension = MockWebServerExtension.builder().server(server).build();
-            extension.afterEach(null);
+            extension.afterEach(extensionContext);
 
             verify(server, only()).close();
         }
@@ -200,7 +209,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .build();
 
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> extension.uri(null))
@@ -215,7 +224,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .build();
 
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             // MinimalBlankStringSource gives us a null, which we need to ignore,
             // so convert it to an empty string.
@@ -239,7 +248,7 @@ class MockWebServerExtensionTest {
                     .server(server)
                     .build();
 
-            extension.beforeEach(null);
+            extension.beforeEach(extensionContext);
 
             // handle the special case of an empty string; the resulting
             // path should end with a slash


### PR DESCRIPTION
Now that extension callback methods and argument provider methods are
annotated with NonNull, passing null directly triggers IntelliJ
warnings. Replace null arguments with mocks initialized in a BeforeEach
method, consistent with the project's test setup convention.