### PR TITLE
chore: extract common logic in JavaTimeArgumentMatchers into a private method

### DIFF
--- a/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
@@ -24,6 +24,8 @@ public class JavaTimeArgumentMatchers {
     private static final int DEFAULT_SLACK_MILLIS = 500;
     private static final String EXPECTED_TIME_CANNOT_BE_NULL = "expectedTime cannot be null";
     private static final String SLACK_CANNOT_BE_NULL = "slack cannot be null";
+    private static final String LOG_TRACE_TEMPLATE =
+            "expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}";
 
     /**
      * Matches an {@link ZonedDateTime} near the given expected time within +/- 500 milliseconds.
@@ -86,7 +88,7 @@ public class JavaTimeArgumentMatchers {
         checkPositive(slackMillis);
 
         return actualTime -> {
-            LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}",
+            LOG.trace(LOG_TRACE_TEMPLATE,
                     expectedTime,
                     actualTime,
                     lazy(() -> Duration.between(expectedTime, actualTime)));
@@ -164,7 +166,7 @@ public class JavaTimeArgumentMatchers {
         checkPositive(slackMillis);
 
         return actualTime -> {
-            LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}",
+            LOG.trace(LOG_TRACE_TEMPLATE,
                     expectedTime,
                     actualTime,
                     lazy(() -> Duration.between(expectedTime, actualTime)));

--- a/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
@@ -169,7 +169,7 @@ public class JavaTimeArgumentMatchers {
             T lowerBound,
             T upperBound) {
 
-        LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}",
+        LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTime, actualTime): {}",
                 expectedTime, actualTime,
                 lazy(() -> Duration.between(expectedTime, actualTime)));
 

--- a/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
@@ -158,13 +158,19 @@ public class JavaTimeArgumentMatchers {
     }
 
     private static <T extends Temporal & Comparable<? super T>> boolean assertIsNear(
-            T expectedTime, T actualTime, T lowerBound, T upperBound) {
+            T expectedTime,
+            T actualTime,
+            T lowerBound,
+            T upperBound) {
+
         LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}",
                 expectedTime, actualTime,
                 lazy(() -> Duration.between(expectedTime, actualTime)));
+
         assertThat(actualTime)
                 .describedAs("actual time %s not between [ %s, %s ]", actualTime, lowerBound, upperBound)
                 .isBetween(lowerBound, upperBound);
+
         return true;
     }
 }

--- a/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
@@ -86,9 +86,12 @@ public class JavaTimeArgumentMatchers {
         checkArgumentNotNull(expectedTime, EXPECTED_TIME_CANNOT_BE_NULL);
         checkPositive(slackMillis);
 
-        return actualTime -> assertIsNear(expectedTime, actualTime,
+        return actualTime -> assertIsNear(
+                expectedTime,
+                actualTime,
                 expectedTime.minus(slackMillis, ChronoUnit.MILLIS),
-                expectedTime.plus(slackMillis, ChronoUnit.MILLIS));
+                expectedTime.plus(slackMillis, ChronoUnit.MILLIS)
+        );
     }
 
     /**
@@ -152,9 +155,12 @@ public class JavaTimeArgumentMatchers {
         checkArgumentNotNull(expectedTime, EXPECTED_TIME_CANNOT_BE_NULL);
         checkPositive(slackMillis);
 
-        return actualTime -> assertIsNear(expectedTime, actualTime,
+        return actualTime -> assertIsNear(
+                expectedTime,
+                actualTime,
                 expectedTime.minusMillis(slackMillis),
-                expectedTime.plusMillis(slackMillis));
+                expectedTime.plusMillis(slackMillis)
+        );
     }
 
     private static <T extends Temporal & Comparable<? super T>> boolean assertIsNear(

--- a/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchers.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
 
 /**
  * Static utility methods to create {@link ArgumentMatcher} instances for types in the {@code java.time} package.
@@ -24,8 +25,6 @@ public class JavaTimeArgumentMatchers {
     private static final int DEFAULT_SLACK_MILLIS = 500;
     private static final String EXPECTED_TIME_CANNOT_BE_NULL = "expectedTime cannot be null";
     private static final String SLACK_CANNOT_BE_NULL = "slack cannot be null";
-    private static final String LOG_TRACE_TEMPLATE =
-            "expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}";
 
     /**
      * Matches an {@link ZonedDateTime} near the given expected time within +/- 500 milliseconds.
@@ -87,21 +86,9 @@ public class JavaTimeArgumentMatchers {
         checkArgumentNotNull(expectedTime, EXPECTED_TIME_CANNOT_BE_NULL);
         checkPositive(slackMillis);
 
-        return actualTime -> {
-            LOG.trace(LOG_TRACE_TEMPLATE,
-                    expectedTime,
-                    actualTime,
-                    lazy(() -> Duration.between(expectedTime, actualTime)));
-
-            var lowerBound = expectedTime.minus(slackMillis, ChronoUnit.MILLIS);
-            var upperBound = expectedTime.plus(slackMillis, ChronoUnit.MILLIS);
-
-            assertThat(actualTime)
-                    .describedAs("actual time %s not between [ %s, %s ]", actualTime, lowerBound, upperBound)
-                    .isBetween(lowerBound, upperBound);
-
-            return true;
-        };
+        return actualTime -> assertIsNear(expectedTime, actualTime,
+                expectedTime.minus(slackMillis, ChronoUnit.MILLIS),
+                expectedTime.plus(slackMillis, ChronoUnit.MILLIS));
     }
 
     /**
@@ -165,20 +152,19 @@ public class JavaTimeArgumentMatchers {
         checkArgumentNotNull(expectedTime, EXPECTED_TIME_CANNOT_BE_NULL);
         checkPositive(slackMillis);
 
-        return actualTime -> {
-            LOG.trace(LOG_TRACE_TEMPLATE,
-                    expectedTime,
-                    actualTime,
-                    lazy(() -> Duration.between(expectedTime, actualTime)));
+        return actualTime -> assertIsNear(expectedTime, actualTime,
+                expectedTime.minusMillis(slackMillis),
+                expectedTime.plusMillis(slackMillis));
+    }
 
-            var lowerBound = expectedTime.minusMillis(slackMillis);
-            var upperBound = expectedTime.plusMillis(slackMillis);
-
-            assertThat(actualTime)
-                    .describedAs("actual time %s not between [ %s, %s ]", actualTime, lowerBound, upperBound)
-                    .isBetween(lowerBound, upperBound);
-
-            return true;
-        };
+    private static <T extends Temporal & Comparable<? super T>> boolean assertIsNear(
+            T expectedTime, T actualTime, T lowerBound, T upperBound) {
+        LOG.trace("expectedTime: {} ; actualTime: {} ; Duration.between(expectedTimeTime, actualTime): {}",
+                expectedTime, actualTime,
+                lazy(() -> Duration.between(expectedTime, actualTime)));
+        assertThat(actualTime)
+                .describedAs("actual time %s not between [ %s, %s ]", actualTime, lowerBound, upperBound)
+                .isBetween(lowerBound, upperBound);
+        return true;
     }
 }

--- a/src/test/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchersTest.java
+++ b/src/test/java/org/kiwiproject/test/mockito/JavaTimeArgumentMatchersTest.java
@@ -83,7 +83,8 @@ class JavaTimeArgumentMatchersTest {
                 var anInstant = callAnnounce(millis);
 
                 assertThatThrownBy(() -> verify(timekeeper).announce(argThat(isNear(anInstant))))
-                        .isInstanceOf(AssertionError.class);
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("not between");
             }
         }
 
@@ -195,7 +196,8 @@ class JavaTimeArgumentMatchersTest {
                 var zonedDateTime = callAnnounce(millis);
 
                 assertThatThrownBy(() -> verify(timekeeper).announce(argThat(isNear(zonedDateTime))))
-                        .isInstanceOf(AssertionError.class);
+                        .isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("not between");
             }
         }
 


### PR DESCRIPTION
The two isNear overloads for ZonedDateTime and Instant shared identical
lambda bodies (logging, assertion, return). Extract into a private
generic assertIsNear method taking Temporal args to eliminate the
duplication.

Also add a message assertion to one shouldFail test per type in
JavaTimeArgumentMatchersTest to verify the describedAs message is
wired up correctly in the extracted method.