### PR TITLE
fix: close Handle objects opened via jdbi.open() in test

### DIFF
--- a/src/test/java/org/kiwiproject/test/junit/jupiter/PostgresLiquibaseTestExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/PostgresLiquibaseTestExtensionTest.java
@@ -55,14 +55,14 @@ class PostgresLiquibaseTestExtensionTest {
     @Test
     @Order(2)
     void shouldAlwaysReturnSameConnection() {
-        var handle1 = jdbi.open();
-        var handle2 = jdbi.open();
-
-        assertThat(handle1.getConnection())
-                .isSameAs(handle2.getConnection())
-                .isSameAs(handle.getConnection());
+        try (var handle1 = jdbi.open(); var handle2 = jdbi.open()) {
+            assertThat(handle1.getConnection())
+                    .isSameAs(handle2.getConnection())
+                    .isSameAs(handle.getConnection());
+        }
     }
 
+    @SuppressWarnings("resource")
     @Test
     @Order(3)
     void shouldUseSameConnection() {


### PR DESCRIPTION
Use try-with-resources for handle1 and handle2 in
PostgresLiquibaseTestExtensionTest#shouldAlwaysReturnSameConnection 
to ensure they are properly closed after the assertion.

Also suppress the false-positive resource warning on shouldUseSameConnection,
where jdbi.withHandle manages the Handle lifecycle internally.