### PR TITLE
feat: add MockitoHelpers utility with mockNeverCalled factory method

### DIFF
--- a/src/main/java/org/kiwiproject/test/mockito/MockitoHelpers.java
+++ b/src/main/java/org/kiwiproject/test/mockito/MockitoHelpers.java
@@ -1,0 +1,46 @@
+package org.kiwiproject.test.mockito;
+
+import static org.mockito.Mockito.mock;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Static utility methods for creating Mockito mocks with specific behaviors.
+ */
+@UtilityClass
+public class MockitoHelpers {
+
+    /**
+     * Creates a {@link org.mockito.Mock mock} of the given class that throws
+     * {@link AssertionError} if any method is invoked.
+     * <p>
+     * Use this when the mock should never be called during the test. The error message will
+     * include the class name and the name of the method that was unexpectedly called.
+     *
+     * @param classToMock the class to mock
+     * @param <T>         the type to mock
+     * @return a new mock instance
+     */
+    public static <T> T mockNeverCalled(Class<T> classToMock) {
+        return mock(classToMock, invocation -> {
+            throw new AssertionError("No methods should be called on this " +
+                    classToMock.getSimpleName() + " mock, but " +
+                    invocation.getMethod().getName() + "() was called");
+        });
+    }
+
+    /**
+     * Creates a {@link org.mockito.Mock mock} of the given class that throws
+     * {@link AssertionError} with the given message if any method is invoked.
+     *
+     * @param classToMock the class to mock
+     * @param message     the AssertionError message
+     * @param <T>         the type to mock
+     * @return a new mock instance
+     */
+    public static <T> T mockNeverCalled(Class<T> classToMock, String message) {
+        return mock(classToMock, invocation -> {
+            throw new AssertionError(message);
+        });
+    }
+}

--- a/src/test/java/org/kiwiproject/test/mockito/MockitoHelpersTest.java
+++ b/src/test/java/org/kiwiproject/test/mockito/MockitoHelpersTest.java
@@ -1,0 +1,57 @@
+package org.kiwiproject.test.mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+@DisplayName("MockitoHelpers")
+class MockitoHelpersTest {
+
+    @Nested
+    class MockNeverCalled {
+
+        @Nested
+        class WithDefaultMessage {
+
+            @Test
+            void shouldReturnNonNullMock() {
+                assertThat(mockNeverCalled(List.class)).isNotNull();
+            }
+
+            @Test
+            void shouldThrowAssertionError_WhenAnyMethodIsCalled() {
+                var mock = mockNeverCalled(List.class);
+
+                //noinspection ResultOfMethodCallIgnored
+                assertThatExceptionOfType(AssertionError.class)
+                        .isThrownBy(mock::size)
+                        .withMessage("No methods should be called on this List mock, but size() was called");
+            }
+        }
+
+        @Nested
+        class WithCustomMessage {
+
+            @Test
+            void shouldReturnNonNullMock() {
+                assertThat(mockNeverCalled(List.class, "List should not be called")).isNotNull();
+            }
+
+            @Test
+            void shouldThrowAssertionError_WithCustomMessage_WhenAnyMethodIsCalled() {
+                var mock = mockNeverCalled(List.class, "List should not be called");
+
+                //noinspection ResultOfMethodCallIgnored
+                assertThatExceptionOfType(AssertionError.class)
+                        .isThrownBy(mock::size)
+                        .withMessage("List should not be called");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add MockitoHelpers in the org.kiwiproject.test.mockito package with
two overloads of mockNeverCalled: one that generates a default message
including the class name and invoked method name, and one that accepts
a custom message. Both throw AssertionError immediately on any method
invocation, giving faster and more descriptive failures than post-hoc
verifyNoInteractions checks.

Closes #668