### PR TITLE
refactor: use MockitoHelpers.mockNeverCalled in tests

### DIFF
--- a/src/test/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/ResetKiwiValidationExtensionTest.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.test.junit.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,8 +20,7 @@ class ResetKiwiValidationExtensionTest {
 
         @BeforeEach
         void setUp() {
-            extensionContext = mock(ExtensionContext.class,
-                    invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+            extensionContext = mockNeverCalled(ExtensionContext.class);
         }
 
         @RepeatedTest(10)

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomDoubleArgumentsProviderTest.java
@@ -2,7 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.Mockito.mock;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,10 +28,8 @@ class RandomDoubleArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class,
-                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
-        parameterDeclarations = mock(ParameterDeclarations.class,
-                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
+        extensionContext = mockNeverCalled(ExtensionContext.class);
+        parameterDeclarations = mockNeverCalled(ParameterDeclarations.class);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomIntArgumentsProviderTest.java
@@ -3,7 +3,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.Mockito.mock;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,10 +24,8 @@ class RandomIntArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class,
-                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
-        parameterDeclarations = mock(ParameterDeclarations.class,
-                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
+        extensionContext = mockNeverCalled(ExtensionContext.class);
+        parameterDeclarations = mockNeverCalled(ParameterDeclarations.class);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomLongArgumentsProviderTest.java
@@ -2,7 +2,7 @@ package org.kiwiproject.test.junit.jupiter.params.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.Mockito.mock;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,10 +23,8 @@ class RandomLongArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class,
-                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
-        parameterDeclarations = mock(ParameterDeclarations.class,
-                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
+        extensionContext = mockNeverCalled(ExtensionContext.class);
+        parameterDeclarations = mockNeverCalled(ParameterDeclarations.class);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
+++ b/src/test/java/org/kiwiproject/test/junit/jupiter/params/provider/RandomStringArgumentsProviderTest.java
@@ -9,7 +9,7 @@ import static org.apache.commons.lang3.CharUtils.isAsciiPrintable;
 import static org.apache.commons.lang3.StringUtils.containsOnly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.Mockito.mock;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -46,10 +46,8 @@ class RandomStringArgumentsProviderTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class,
-                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
-        parameterDeclarations = mock(ParameterDeclarations.class,
-                invocation -> { throw new AssertionError("ParameterDeclarations should not be called"); });
+        extensionContext = mockNeverCalled(ExtensionContext.class);
+        parameterDeclarations = mockNeverCalled(ParameterDeclarations.class);
     }
 
     @ParameterizedTest

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/MockWebServerExtensionTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -35,8 +36,7 @@ class MockWebServerExtensionTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class,
-                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+        extensionContext = mockNeverCalled(ExtensionContext.class);
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/MockWebServerExtensionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.kiwiproject.test.mockito.MockitoHelpers.mockNeverCalled;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -34,8 +35,7 @@ class MockWebServerExtensionTest {
 
     @BeforeEach
     void setUp() {
-        extensionContext = mock(ExtensionContext.class,
-                invocation -> { throw new AssertionError("ExtensionContext should not be called"); });
+        extensionContext = mockNeverCalled(ExtensionContext.class);
     }
 
     @Nested


### PR DESCRIPTION
Replace the manual mock-with-throwing-answer pattern with the new
mockNeverCalled utility method in all affected test classes.

Affected files:
- ResetKiwiValidationExtensionTest
- RandomDoubleArgumentsProviderTest
- RandomLongArgumentsProviderTest
- RandomIntArgumentsProviderTest
- RandomStringArgumentsProviderTest
- MockWebServerExtensionTest (mockwebserver)
- MockWebServerExtensionTest (mockwebserver3)