### PR TITLE
feat: add hasHeader(name) and hasHeaderSatisfying to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -282,6 +282,39 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a header with the given name (regardless of value).
+     *
+     * @param name the HTTP header name
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeader(String name) {
+        Assertions.assertThat(recordedRequest.getHeader(name))
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * satisfies assertions in the given consumer.
+     *
+     * @param name          the HTTP header name
+     * @param valueConsumer a {@link Consumer} containing one or more assertions on the header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderSatisfying(String name, Consumer<String> valueConsumer) {
+        var value = recordedRequest.getHeader(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+
+        valueConsumer.accept(value);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request does not have a request body.
      * <p>
      * Only DELETE, PATCH, POST, and PUT may have a body.

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -284,6 +284,39 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a header with the given name (regardless of value).
+     *
+     * @param name the HTTP header name
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeader(String name) {
+        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * satisfies assertions in the given consumer.
+     *
+     * @param name          the HTTP header name
+     * @param valueConsumer a {@link Consumer} containing one or more assertions on the header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderSatisfying(String name, Consumer<String> valueConsumer) {
+        var value = recordedRequest.getHeaders().get(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+
+        valueConsumer.accept(value);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request does not have a request body.
      * <p>
      * Only DELETE, PATCH, POST, and PUT may have a body.

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -579,6 +579,49 @@ class RecordedRequestAssertionsTest {
                     .isNotNull()
                     .hasMessageContaining("Expected Accept header to have value: application/json");
         }
+
+        @Test
+        void shouldCheckHeaderPresence() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Accept"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckHeaderPresence_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Authorization"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
+
+        @Test
+        void shouldCheckHeaderSatisfying_WhenValueSatisfiesCondition() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderSatisfying("Accept", value -> {
+                        assertThat(value).startsWith("text/html");
+                        assertThat(value).contains("charset");
+                    }))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckHeaderSatisfying_WhenValueDoesNotSatisfyCondition() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderSatisfying("Accept", value ->
+                            assertThat(value).isEqualTo("application/json")))
+                    .isNotNull()
+                    .hasMessageContaining("application/json");
+        }
+
+        @Test
+        void shouldCheckHeaderSatisfying_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderSatisfying("Authorization", value ->
+                            assertThat(value).isNotNull()))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -567,6 +567,49 @@ class RecordedRequestAssertionsTest {
                     .isNotNull()
                     .hasMessageContaining("Expected Accept header to have value: application/json");
         }
+
+        @Test
+        void shouldCheckHeaderPresence() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Accept"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckHeaderPresence_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeader("Authorization"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
+
+        @Test
+        void shouldCheckHeaderSatisfying_WhenValueSatisfiesCondition() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderSatisfying("Accept", value -> {
+                        assertThat(value).startsWith("text/html");
+                        assertThat(value).contains("charset");
+                    }))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckHeaderSatisfying_WhenValueDoesNotSatisfyCondition() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderSatisfying("Accept", value ->
+                            assertThat(value).isEqualTo("application/json")))
+                    .isNotNull()
+                    .hasMessageContaining("application/json");
+        }
+
+        @Test
+        void shouldCheckHeaderSatisfying_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderSatisfying("Authorization", value ->
+                            assertThat(value).isNotNull()))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
     }
 
     @Nested


### PR DESCRIPTION
Add two new header assertion methods to RecordedRequestAssertions in
both the mockwebserver and mockwebserver3 packages.

hasHeader(String name) asserts a header is present with any value,
complementing the existing hasHeader(String name, Object value) overload.
This covers the common case where the test only cares that a header was
sent, not its specific value.

hasHeaderSatisfying(String name, Consumer<String> valueConsumer) asserts
the header is present and then delegates value assertions to a consumer,
following the same pattern as the existing hasBodySatisfying method. The
presence check runs first so that a missing header produces a clear
"Expected header X to be present" failure rather than a confusing null
assertion inside the consumer.

Both methods are added symmetrically to the mockwebserver and mockwebserver3
variants and covered by tests in the corresponding test classes.