### PR TITLE
feat: add hasNoHeader assertion to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -296,6 +296,20 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request does not have a header with the given name.
+     *
+     * @param name the HTTP header name
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasNoHeader(String name) {
+        Assertions.assertThat(recordedRequest.getHeader(name))
+                .describedAs("Expected header %s not to be present", name)
+                .isNull();
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a header with the given name and whose value
      * satisfies assertions in the given consumer.
      *

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -298,6 +298,20 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request does not have a header with the given name.
+     *
+     * @param name the HTTP header name
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasNoHeader(String name) {
+        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+                .describedAs("Expected header %s not to be present", name)
+                .isNull();
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a header with the given name and whose value
      * satisfies assertions in the given consumer.
      *

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -596,6 +596,21 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckNoHeader_WhenHeaderIsAbsent() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasNoHeader("Authorization"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckNoHeader_WhenHeaderIsPresent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasNoHeader("Accept"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Accept not to be present");
+        }
+
+        @Test
         void shouldCheckHeaderSatisfying_WhenValueSatisfiesCondition() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeaderSatisfying("Accept", value -> {

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -584,6 +584,21 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckNoHeader_WhenHeaderIsAbsent() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasNoHeader("Authorization"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckNoHeader_WhenHeaderIsPresent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasNoHeader("Accept"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Accept not to be present");
+        }
+
+        @Test
         void shouldCheckHeaderSatisfying_WhenValueSatisfiesCondition() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeaderSatisfying("Accept", value -> {


### PR DESCRIPTION
Add hasNoHeader(String name) to RecordedRequestAssertions in both the
mockwebserver and mockwebserver3 packages.

This is the natural complement to the hasHeader(String name) overload
added in #672. Asserting that a header was not sent is equally valid
as asserting it was — particularly for security-sensitive cases like
verifying an Authorization header was not leaked in a particular request.