### PR TITLE
feat: add hasHeaderValueEndingWith to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -32,6 +32,8 @@ public class RecordedRequestAssertions {
     // reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
     static final List<String> METHODS_ALLOWING_BODY = List.of("DELETE", "PATCH", "POST", "PUT");
 
+    private static final String HEADER_MUST_BE_PRESENT = "Expected header %s to be present";
+
     private final RecordedRequest recordedRequest;
 
     private RecordedRequestAssertions(RecordedRequest recordedRequest) {
@@ -260,7 +262,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderValueStartingWith(String name, String prefix) {
         var value = recordedRequest.getHeader(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
         Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value starting with: %s", name, prefix)
@@ -280,7 +282,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderValueContaining(String name, String substring) {
         var value = recordedRequest.getHeader(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
         Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value containing: %s", name, substring)
@@ -300,7 +302,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderValueEndingWith(String name, String suffix) {
         var value = recordedRequest.getHeader(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
         Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value ending with: %s", name, suffix)
@@ -317,7 +319,7 @@ public class RecordedRequestAssertions {
      */
     public RecordedRequestAssertions hasHeader(String name) {
         Assertions.assertThat(recordedRequest.getHeader(name))
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
 
         return this;
@@ -348,7 +350,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderSatisfying(String name, Consumer<String> valueConsumer) {
         var value = recordedRequest.getHeader(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
 
         valueConsumer.accept(value);

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -258,7 +258,11 @@ public class RecordedRequestAssertions {
      * @return this instance
      */
     public RecordedRequestAssertions hasHeaderValueStartingWith(String name, String prefix) {
-        Assertions.assertThat(recordedRequest.getHeader(name))
+        var value = recordedRequest.getHeader(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+        Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value starting with: %s", name, prefix)
                 .startsWith(prefix);
 
@@ -274,7 +278,11 @@ public class RecordedRequestAssertions {
      * @return this instance
      */
     public RecordedRequestAssertions hasHeaderValueContaining(String name, String substring) {
-        Assertions.assertThat(recordedRequest.getHeader(name))
+        var value = recordedRequest.getHeader(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+        Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value containing: %s", name, substring)
                 .contains(substring);
 
@@ -290,7 +298,11 @@ public class RecordedRequestAssertions {
      * @return this instance
      */
     public RecordedRequestAssertions hasHeaderValueEndingWith(String name, String suffix) {
-        Assertions.assertThat(recordedRequest.getHeader(name))
+        var value = recordedRequest.getHeader(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+        Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value ending with: %s", name, suffix)
                 .endsWith(suffix);
 

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -282,6 +282,22 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * ends with the given suffix.
+     *
+     * @param name   the HTTP header name
+     * @param suffix the expected suffix of the HTTP header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderValueEndingWith(String name, String suffix) {
+        Assertions.assertThat(recordedRequest.getHeader(name))
+                .describedAs("Expected %s header to have value ending with: %s", name, suffix)
+                .endsWith(suffix);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a header with the given name (regardless of value).
      *
      * @param name the HTTP header name

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -284,6 +284,22 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a header with the given name and whose value
+     * ends with the given suffix.
+     *
+     * @param name   the HTTP header name
+     * @param suffix the expected suffix of the HTTP header value
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasHeaderValueEndingWith(String name, String suffix) {
+        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+                .describedAs("Expected %s header to have value ending with: %s", name, suffix)
+                .endsWith(suffix);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a header with the given name (regardless of value).
      *
      * @param name the HTTP header name

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -260,7 +260,11 @@ public class RecordedRequestAssertions {
      * @return this instance
      */
     public RecordedRequestAssertions hasHeaderValueStartingWith(String name, String prefix) {
-        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+        var value = recordedRequest.getHeaders().get(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+        Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value starting with: %s", name, prefix)
                 .startsWith(prefix);
 
@@ -276,7 +280,11 @@ public class RecordedRequestAssertions {
      * @return this instance
      */
     public RecordedRequestAssertions hasHeaderValueContaining(String name, String substring) {
-        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+        var value = recordedRequest.getHeaders().get(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+        Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value containing: %s", name, substring)
                 .contains(substring);
 
@@ -292,7 +300,11 @@ public class RecordedRequestAssertions {
      * @return this instance
      */
     public RecordedRequestAssertions hasHeaderValueEndingWith(String name, String suffix) {
-        Assertions.assertThat(recordedRequest.getHeaders().get(name))
+        var value = recordedRequest.getHeaders().get(name);
+        Assertions.assertThat(value)
+                .describedAs("Expected header %s to be present", name)
+                .isNotNull();
+        Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value ending with: %s", name, suffix)
                 .endsWith(suffix);
 

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -32,6 +32,8 @@ public class RecordedRequestAssertions {
     // reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
     static final List<String> METHODS_ALLOWING_BODY = List.of("DELETE", "PATCH", "POST", "PUT");
 
+    private static final String HEADER_MUST_BE_PRESENT = "Expected header %s to be present";
+
     private final RecordedRequest recordedRequest;
 
     private RecordedRequestAssertions(RecordedRequest recordedRequest) {
@@ -262,7 +264,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderValueStartingWith(String name, String prefix) {
         var value = recordedRequest.getHeaders().get(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
         Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value starting with: %s", name, prefix)
@@ -282,7 +284,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderValueContaining(String name, String substring) {
         var value = recordedRequest.getHeaders().get(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
         Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value containing: %s", name, substring)
@@ -302,7 +304,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderValueEndingWith(String name, String suffix) {
         var value = recordedRequest.getHeaders().get(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
         Assertions.assertThat(value)
                 .describedAs("Expected %s header to have value ending with: %s", name, suffix)
@@ -319,7 +321,7 @@ public class RecordedRequestAssertions {
      */
     public RecordedRequestAssertions hasHeader(String name) {
         Assertions.assertThat(recordedRequest.getHeaders().get(name))
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
 
         return this;
@@ -350,7 +352,7 @@ public class RecordedRequestAssertions {
     public RecordedRequestAssertions hasHeaderSatisfying(String name, Consumer<String> valueConsumer) {
         var value = recordedRequest.getHeaders().get(name);
         Assertions.assertThat(value)
-                .describedAs("Expected header %s to be present", name)
+                .describedAs(HEADER_MUST_BE_PRESENT, name)
                 .isNotNull();
 
         valueConsumer.accept(value);

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -566,6 +566,21 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckHeaderValueEndingWith() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueEndingWith("Accept", "charset=utf-8"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeaderValueEndingWith() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueEndingWith("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value ending with: application/json");
+        }
+
+        @Test
         void shouldCheckHeader() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeader("Accept", "text/html; charset=utf-8"))

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -551,6 +551,14 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckHeaderValueStartingWith_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueStartingWith("Authorization", "Bearer"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
+
+        @Test
         void shouldCheckHeaderValueContaining() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeaderValueContaining("Accept", "charset"))
@@ -566,6 +574,14 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckHeaderValueContaining_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueContaining("Authorization", "Bearer"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
+
+        @Test
         void shouldCheckHeaderValueEndingWith() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeaderValueEndingWith("Accept", "charset=utf-8"))
@@ -578,6 +594,14 @@ class RecordedRequestAssertionsTest {
                     .hasHeaderValueEndingWith("Accept", "application/json"))
                     .isNotNull()
                     .hasMessageContaining("Expected Accept header to have value ending with: application/json");
+        }
+
+        @Test
+        void shouldCheckHeaderValueEndingWith_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueEndingWith("Authorization", "token"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
         }
 
         @Test

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -554,6 +554,21 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckHeaderValueEndingWith() {
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueEndingWith("Accept", "charset=utf-8"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidHeaderValueEndingWith() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueEndingWith("Accept", "application/json"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected Accept header to have value ending with: application/json");
+        }
+
+        @Test
         void shouldCheckHeader() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeader("Accept", "text/html; charset=utf-8"))

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -539,6 +539,14 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckHeaderValueStartingWith_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueStartingWith("Authorization", "Bearer"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
+
+        @Test
         void shouldCheckHeaderValueContaining() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeaderValueContaining("Accept", "charset"))
@@ -554,6 +562,14 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckHeaderValueContaining_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueContaining("Authorization", "Bearer"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
+        }
+
+        @Test
         void shouldCheckHeaderValueEndingWith() {
             assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
                     .hasHeaderValueEndingWith("Accept", "charset=utf-8"))
@@ -566,6 +582,14 @@ class RecordedRequestAssertionsTest {
                     .hasHeaderValueEndingWith("Accept", "application/json"))
                     .isNotNull()
                     .hasMessageContaining("Expected Accept header to have value ending with: application/json");
+        }
+
+        @Test
+        void shouldCheckHeaderValueEndingWith_WhenHeaderIsAbsent() {
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasHeaderValueEndingWith("Authorization", "token"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected header Authorization to be present");
         }
 
         @Test


### PR DESCRIPTION
Add hasHeaderValueEndingWith(String name, String suffix) to
RecordedRequestAssertions in both the mockwebserver and mockwebserver3
packages, completing the StartsWith/Contains/EndsWith triad for header
value partial-match assertions.

Also fixes a latent bug in hasHeaderValueStartingWith and
hasHeaderValueContaining: when the named header was absent, all three
methods previously failed with a confusing AssertJ null message rather
than a clear explanation. Each method now checks for header presence
first and fails with "Expected header X to be present" before
attempting the value assertion.