### PR TITLE
feat: add isTls() to mockwebserver RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -491,6 +491,19 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request is TLS, i.e., is an HTTPS request.
+     *
+     * @return this instance
+     */
+    public RecordedRequestAssertions isTls() {
+        Assertions.assertThat(recordedRequest.getTlsVersion())
+                .describedAs("Expected request to use TLS")
+                .isNotNull();
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request is not TLS, i.e., is an HTTP request not HTTPS.
      *
      * @return this instance

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -11,6 +11,7 @@ import static org.kiwiproject.test.okhttp3.mockwebserver.RecordedRequestAssertio
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import okhttp3.TlsVersion;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -772,6 +773,39 @@ class RecordedRequestAssertionsTest {
                     .hasFailureCauseInstanceOf(SSLHandshakeException.class))
                     .isNotNull()
                     .hasMessageContaining("Expected request to have failure of type: javax.net.ssl.SSLHandshakeException");
+        }
+    }
+
+    @Nested
+    class Tls {
+
+        @Test
+        void shouldPassWhenRequestIsTls() {
+            var tlsRequest = mock(RecordedRequest.class);
+            when(tlsRequest.getTlsVersion()).thenReturn(TlsVersion.TLS_1_3);
+
+            assertThatCode(() -> assertThatRecordedRequest(tlsRequest).isTls())
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldFailWhenRequestIsNotTls_ButTlsExpected() {
+            var nonTlsRequest = mock(RecordedRequest.class);
+            when(nonTlsRequest.getTlsVersion()).thenReturn(null);
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(nonTlsRequest).isTls())
+                    .isNotNull()
+                    .hasMessageContaining("Expected request to use TLS");
+        }
+
+        @Test
+        void shouldFailWhenRequestIsTls_ButNotTlsExpected() {
+            var tlsRequest = mock(RecordedRequest.class);
+            when(tlsRequest.getTlsVersion()).thenReturn(TlsVersion.TLS_1_3);
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(tlsRequest).isNotTls())
+                    .isNotNull()
+                    .hasMessageContaining("Expected request not to use TLS");
         }
     }
 


### PR DESCRIPTION
The mockwebserver3 variant already had isTls() alongside isNotTls(),
but the older mockwebserver only had isNotTls() and hasTlsVersion().

Add isTls() to close the asymmetry. Also adds a dedicated Tls nested
test class to the mockwebserver test, covering isTls(), isNotTls(), and
the failure case for each — where previously only isNotTls() was
exercised inline in the main happy-path test.