### PR TITLE
feat: add partial path/target matching to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -237,6 +237,48 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a path starting with the given prefix.
+     *
+     * @param prefix the expected path prefix
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasPathStartingWith(String prefix) {
+        Assertions.assertThat(recordedRequest.getPath())
+                .describedAs("Expected path to start with: %s", prefix)
+                .startsWith(prefix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a path containing the given substring.
+     *
+     * @param substring the expected path substring
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasPathContaining(String substring) {
+        Assertions.assertThat(recordedRequest.getPath())
+                .describedAs("Expected path to contain: %s", substring)
+                .contains(substring);
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a path ending with the given suffix.
+     *
+     * @param suffix the expected path suffix
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasPathEndingWith(String suffix) {
+        Assertions.assertThat(recordedRequest.getPath())
+                .describedAs("Expected path to end with: %s", suffix)
+                .endsWith(suffix);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has the expected header name and value.
      *
      * @param name  the expected HTTP header name

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -239,6 +239,51 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a target starting with the given prefix.
+     *
+     * @param prefix the expected target prefix
+     * @return this instance
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1">RFC 7230 - Request Line</a>
+     */
+    public RecordedRequestAssertions hasTargetStartingWith(String prefix) {
+        Assertions.assertThat(recordedRequest.getTarget())
+                .describedAs("Expected target to start with: %s", prefix)
+                .startsWith(prefix);
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a target containing the given substring.
+     *
+     * @param substring the expected target substring
+     * @return this instance
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1">RFC 7230 - Request Line</a>
+     */
+    public RecordedRequestAssertions hasTargetContaining(String substring) {
+        Assertions.assertThat(recordedRequest.getTarget())
+                .describedAs("Expected target to contain: %s", substring)
+                .contains(substring);
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request has a target ending with the given suffix.
+     *
+     * @param suffix the expected target suffix
+     * @return this instance
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1">RFC 7230 - Request Line</a>
+     */
+    public RecordedRequestAssertions hasTargetEndingWith(String suffix) {
+        Assertions.assertThat(recordedRequest.getTarget())
+                .describedAs("Expected target to end with: %s", suffix)
+                .endsWith(suffix);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has the expected header name and value.
      *
      * @param name  the expected HTTP header name

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -838,6 +838,81 @@ class RecordedRequestAssertionsTest {
                     .isNotNull()
                     .hasMessageContaining("Expected path to be: /users/84");
         }
+
+        @Test
+        void shouldCheckPathStartingWith() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathStartingWith("/users"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidPathStartingWith() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathStartingWith("/orders"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected path to start with: /orders");
+        }
+
+        @Test
+        void shouldCheckPathContaining() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42/settings"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathContaining("/42/"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidPathContaining() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42/settings"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathContaining("/99/"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected path to contain: /99/");
+        }
+
+        @Test
+        void shouldCheckPathEndingWith() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathEndingWith("/42"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidPathEndingWith() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathEndingWith("/99"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected path to end with: /99");
+        }
     }
 
     private RecordedRequest takeRequest() {

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -817,6 +817,81 @@ class RecordedRequestAssertionsTest {
                     .isNotNull()
                     .hasMessageContaining("Expected target to be: /users/84");
         }
+
+        @Test
+        void shouldCheckTargetStartingWith() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetStartingWith("/users"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidTargetStartingWith() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetStartingWith("/orders"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected target to start with: /orders");
+        }
+
+        @Test
+        void shouldCheckTargetContaining() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42/settings"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetContaining("/42/"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidTargetContaining() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42/settings"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetContaining("/99/"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected target to contain: /99/");
+        }
+
+        @Test
+        void shouldCheckTargetEndingWith() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetEndingWith("/42"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidTargetEndingWith() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetEndingWith("/99"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected target to end with: /99");
+        }
     }
 
     private RecordedRequest takeRequest() {


### PR DESCRIPTION
Add hasPathStartingWith, hasPathContaining, and hasPathEndingWith to
the mockwebserver package, and hasTargetStartingWith, hasTargetContaining,
and hasTargetEndingWith to the mockwebserver3 package.

These complement the existing exact-match hasPath/hasTarget methods and
are consistent with the StartsWith/Contains/EndsWith triad already
present for header value assertions.