### PR TITLE
feat: add hasBodyContaining to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -456,6 +456,24 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a body containing the given substring.
+     *
+     * @param substring the expected substring of the request body
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasBodyContaining(String substring) {
+        checkMethodAllowsBody();
+
+        var bodyBuffer = recordedRequest.getBody();
+        var actualBodyUtf8 = bodyBuffer.readUtf8();
+        Assertions.assertThat(actualBodyUtf8)
+                .describedAs("Expected body to contain: %s", substring)
+                .contains(substring);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a JSON body that deserializes to the given entity.
      *
      * @param entity the expected request entity

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -457,6 +457,23 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a body containing the given substring.
+     *
+     * @param substring the expected substring of the request body
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasBodyContaining(String substring) {
+        checkMethodAllowsBody();
+
+        var actualBodyUtf8 = bodyUtf8();
+        Assertions.assertThat(actualBodyUtf8)
+                .describedAs("Expected body to contain: %s", substring)
+                .contains(substring);
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a JSON body that deserializes to the given entity.
      *
      * @param entity the expected request entity

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -208,6 +208,23 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckBodyContaining() {
+            assertThatCode(() ->
+                    assertThatRecordedRequest(recordedRequest)
+                            .hasBodyContaining("alice"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidBodyContaining() {
+            assertThatThrownBy(() ->
+                    assertThatRecordedRequest(recordedRequest)
+                            .hasBodyContaining("mallory"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected body to contain: mallory");
+        }
+
+        @Test
         void shouldCheckInvalidBodySize() {
             assertThatThrownBy(() -> RecordedRequestAssertions.assertThat(recordedRequest).hasBodySize(2_567))
                     .isNotNull()

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -208,6 +208,23 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckBodyContaining() {
+            assertThatCode(() ->
+                    assertThatRecordedRequest(recordedRequest)
+                            .hasBodyContaining("alice"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidBodyContaining() {
+            assertThatThrownBy(() ->
+                    assertThatRecordedRequest(recordedRequest)
+                            .hasBodyContaining("mallory"))
+                    .isNotNull()
+                    .hasMessageContaining("Expected body to contain: mallory");
+        }
+
+        @Test
         void shouldCheckInvalidBodySize() {
             assertThatThrownBy(() -> RecordedRequestAssertions.assertThat(recordedRequest).hasBodySize(2_567))
                     .isNotNull()


### PR DESCRIPTION
Add hasBodyContaining(String substring) to RecordedRequestAssertions in
both the mockwebserver and mockwebserver3 packages.

This provides a readable shortcut for the common case of asserting that
a specific field or value appears somewhere in the request body, without
needing a hasBodySatisfying consumer.