### PR TITLE
feat: add hasPathSatisfying and hasTargetSatisfying to RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertions.java
@@ -237,6 +237,18 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a path that satisfies assertions in the given consumer.
+     *
+     * @param pathConsumer a {@link Consumer} containing one or more assertions on the request path
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasPathSatisfying(Consumer<String> pathConsumer) {
+        pathConsumer.accept(recordedRequest.getPath());
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a path starting with the given prefix.
      *
      * @param prefix the expected path prefix

--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -239,6 +239,19 @@ public class RecordedRequestAssertions {
     }
 
     /**
+     * Asserts the recorded request has a target that satisfies assertions in the given consumer.
+     *
+     * @param targetConsumer a {@link Consumer} containing one or more assertions on the request target
+     * @return this instance
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1">RFC 7230 - Request Line</a>
+     */
+    public RecordedRequestAssertions hasTargetSatisfying(Consumer<String> targetConsumer) {
+        targetConsumer.accept(recordedRequest.getTarget());
+
+        return this;
+    }
+
+    /**
      * Asserts the recorded request has a target starting with the given prefix.
      *
      * @param prefix the expected target prefix

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver/RecordedRequestAssertionsTest.java
@@ -857,6 +857,34 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckPathSatisfying_WhenPathSatisfiesCondition() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathSatisfying(path -> {
+                        assertThat(path).startsWith("/users");
+                        assertThat(path).endsWith("/42");
+                    }))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckPathSatisfying_WhenPathDoesNotSatisfyCondition() {
+            server.enqueue(new MockResponse());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasPathSatisfying(path -> assertThat(path).startsWith("/orders")))
+                    .isNotNull()
+                    .hasMessageContaining("/orders");
+        }
+
+        @Test
         void shouldCheckPathStartingWith() {
             server.enqueue(new MockResponse());
             JdkHttpClients.get(httpClient, uri("/users/42"));

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -836,6 +836,34 @@ class RecordedRequestAssertionsTest {
         }
 
         @Test
+        void shouldCheckTargetSatisfying_WhenTargetSatisfiesCondition() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatCode(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetSatisfying(target -> {
+                        assertThat(target).startsWith("/users");
+                        assertThat(target).endsWith("/42");
+                    }))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckTargetSatisfying_WhenTargetDoesNotSatisfyCondition() {
+            server.enqueue(new MockResponse.Builder().code(200).build());
+            JdkHttpClients.get(httpClient, uri("/users/42"));
+
+            var recordedRequest = takeRequest();
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(recordedRequest)
+                    .hasTargetSatisfying(target -> assertThat(target).startsWith("/orders")))
+                    .isNotNull()
+                    .hasMessageContaining("/orders");
+        }
+
+        @Test
         void shouldCheckTargetStartingWith() {
             server.enqueue(new MockResponse.Builder().code(200).build());
             JdkHttpClients.get(httpClient, uri("/users/42"));


### PR DESCRIPTION
Add hasPathSatisfying(Consumer<String>) to the mockwebserver package and
hasTargetSatisfying(Consumer<String>) to the mockwebserver3 package,
consistent with the existing hasHeaderSatisfying and hasBodySatisfying
methods.