### PR TITLE
feat: add hasTlsVersion to mockwebserver3 RecordedRequestAssertions

### DIFF
--- a/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
+++ b/src/main/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertions.java
@@ -9,6 +9,7 @@ import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import mockwebserver3.RecordedRequest;
+import okhttp3.TlsVersion;
 import org.assertj.core.api.Assertions;
 import org.kiwiproject.json.JsonHelper;
 
@@ -589,6 +590,24 @@ public class RecordedRequestAssertions {
         Assertions.assertThat(recordedRequest.getHandshake())
                 .describedAs("Expected request to use TLS")
                 .isNotNull();
+
+        return this;
+    }
+
+    /**
+     * Asserts the recorded request is TLS with the expected version.
+     *
+     * @param tlsVersion the expected TLS version
+     * @return this instance
+     */
+    public RecordedRequestAssertions hasTlsVersion(TlsVersion tlsVersion) {
+        var handshake = recordedRequest.getHandshake();
+        Assertions.assertThat(handshake)
+                .describedAs("Expected request to use TLS")
+                .isNotNull();
+        Assertions.assertThat(handshake.tlsVersion())
+                .describedAs("Expected TLS version to be %s", tlsVersion)
+                .isEqualTo(tlsVersion);
 
         return this;
     }

--- a/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
+++ b/src/test/java/org/kiwiproject/test/okhttp3/mockwebserver3/RecordedRequestAssertionsTest.java
@@ -15,6 +15,7 @@ import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
 import okhttp3.Handshake;
+import okhttp3.TlsVersion;
 import okio.ByteString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -802,6 +803,41 @@ class RecordedRequestAssertionsTest {
             assertThatThrownBy(() -> assertThatRecordedRequest(tlsRequest).isNotTls())
                     .isNotNull()
                     .hasMessageContaining("Expected request not to use TLS");
+        }
+
+        @Test
+        void shouldCheckTlsVersion() {
+            var handshake = mock(Handshake.class);
+            when(handshake.tlsVersion()).thenReturn(TlsVersion.TLS_1_3);
+
+            var tlsRequest = mock(RecordedRequest.class);
+            when(tlsRequest.getHandshake()).thenReturn(handshake);
+
+            assertThatCode(() -> assertThatRecordedRequest(tlsRequest).hasTlsVersion(TlsVersion.TLS_1_3))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldCheckInvalidTlsVersion() {
+            var handshake = mock(Handshake.class);
+            when(handshake.tlsVersion()).thenReturn(TlsVersion.TLS_1_2);
+
+            var tlsRequest = mock(RecordedRequest.class);
+            when(tlsRequest.getHandshake()).thenReturn(handshake);
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(tlsRequest).hasTlsVersion(TlsVersion.TLS_1_3))
+                    .isNotNull()
+                    .hasMessageContaining("Expected TLS version to be TLS_1_3");
+        }
+
+        @Test
+        void shouldCheckTlsVersion_WhenRequestIsNotTls() {
+            var nonTlsRequest = mock(RecordedRequest.class);
+            when(nonTlsRequest.getHandshake()).thenReturn(null);
+
+            assertThatThrownBy(() -> assertThatRecordedRequest(nonTlsRequest).hasTlsVersion(TlsVersion.TLS_1_3))
+                    .isNotNull()
+                    .hasMessageContaining("Expected request to use TLS");
         }
     }
 


### PR DESCRIPTION
The mockwebserver variant already had hasTlsVersion(TlsVersion), but
mockwebserver3 only had isTls() and isNotTls(). Add hasTlsVersion to
close the symmetry gap.

The implementation asserts the handshake is non-null first so a non-TLS
request produces a clear "Expected request to use TLS" failure before
attempting to check the TLS version.